### PR TITLE
add db option to scripts and controllers

### DIFF
--- a/GDPRuler.py
+++ b/GDPRuler.py
@@ -1,75 +1,41 @@
-import sys
 import json
 import argparse
 import subprocess
-import pexpect
-import time
 import os
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-policy_compiler_dir = os.path.join(script_dir, './policy_compiler')
-sys.path.insert(1, policy_compiler_dir) # add the policy compiler in sys path
-from helper import safe_open
-from query_analyser import analyze_query
-from policy_config import parse_user_policy
+from common import execute_queries, DbType
+from policy_compiler.helper import safe_open
+from policy_compiler.policy_config import parse_user_policy
 
 # NOTE: we use send(str+"\n") to communicate with the process because the sendline() hangs with 0 delaybeforesend
 
 def main():
   parser = argparse.ArgumentParser(description='Start GDPRuler instance for a specific workload.')
-  parser.add_argument('-c', '--config', help='path to the default config trace file', 
-                        dest='config', default=None, nargs=1, required=True, type=str)
-  parser.add_argument('-w', '--workload', help='path to the workload trace file', 
-                        dest='workload', default=None, nargs=1, required=True, type=str)
-  args = parser.parse_args(sys.argv[1:]) # to exclude the script name
+  parser.add_argument('--config', help='path to the default config trace file', default=None, required=True, type=str)
+  parser.add_argument('--workload', help='path to the workload trace file', default=None, required=True, type=str)
+  parser.add_argument('--db', help='db to use, one of {rocksdb,redis}', default=DbType.ROCKSDB, required=False, type=DbType)
+  parser.add_argument('--address', help='db ip address for client to connect', default=None, required=False, type=str)
+  args = parser.parse_args()
 
-  config_file = args.config[0] # the file containing the default user configuration
-  workload_file = args.workload[0] # the file containing the queries to test
-
-  user_policy = safe_open(config_file, "r")
+  user_policy = safe_open(args.config, "r") # open the file containing the default user configuration
   user_policy = json.load(user_policy)
-
-  # Open the controller process
-  exec_file = os.path.join(script_dir, './controller/build/gdpr_controller')
-  controller = subprocess.Popen([exec_file], stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-
-  # Start the time measurement before sending the default policy
-  start_time = time.perf_counter_ns()
 
   # Set up the default policy in the gdpr controller
   def_policy = parse_user_policy(user_policy)
 
-  # Write to process' standard input
+  # Open the controller process
+  process_args = [os.path.join(os.path.dirname(os.path.abspath(__file__)), './controller/build/gdpr_controller')]
+  process_args += ['--db', args.db]
+  if args.address:
+    process_args += ['--address', args.address]
+  controller = subprocess.Popen(process_args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+
+  # Write policy to process' standard input
   controller.stdin.write(def_policy.encode() + b'\n')
   controller.stdin.flush()
 
-  # Parse and send the query args to the gdpr controller
-  workload_file = safe_open(workload_file, "r")
-  queries = workload_file.readlines()
-
-  for query in queries:
-    new_query = analyze_query(query.rstrip())
-    controller.stdin.write(new_query.encode() + b'\n')
-    controller.stdin.flush()
-
-  controller.stdin.write(b'exit\n')
-  controller.stdin.flush()
-
-  # Read process' standard output and error
-  output, error = controller.communicate()
-  controller.terminate()
-
-  # End the timer after the controller has returned and analyse the measurements
-  end_time = time.perf_counter_ns()
-  runtime = end_time - start_time
-
-  # Print the output of the controller process
-  if error:
-    print(error.decode('utf-8'))
-
-  # Print the timer results
-  seconds = runtime / 1000000000
-  print("System time: {:.9f} s".format(seconds))
+  # Execute queries
+  execute_queries(controller, args.workload)
 
   return
 

--- a/common.py
+++ b/common.py
@@ -1,0 +1,44 @@
+import time
+
+from enum import Enum
+
+from policy_compiler.helper import safe_open
+from policy_compiler.query_analyser import analyze_query
+
+class DbType(str, Enum):
+  """GDPRuler db type."""
+
+  ROCKSDB = "rocksdb"
+  REDIS = "redis"
+
+def execute_queries(controller, workload_file):
+  # Start the time measurement before sending the workload
+  start_time = time.perf_counter_ns()
+
+  # Parse and send the query args to the native controller
+  workload_file = safe_open(workload_file, "r")
+  queries = workload_file.readlines()
+
+  for query in queries:
+    new_query = analyze_query(query.rstrip())
+    controller.stdin.write(new_query.encode() + b'\n')
+    controller.stdin.flush()
+
+  controller.stdin.write(b'exit\n')
+  controller.stdin.flush()
+
+  # Read process' standard output and error
+  _, error = controller.communicate()
+  controller.terminate()
+
+  # End the timer after the controller has returned and analyse the measurements
+  end_time = time.perf_counter_ns()
+  runtime = end_time - start_time
+
+  # Print the output of the controller process
+  if error:
+    print(error.decode('utf-8'))
+
+  # Print the timer results
+  seconds = runtime / 1000000000
+  print("System time: {:.9f} s".format(seconds))

--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -1,4 +1,24 @@
 #pragma once
 
+#include <vector>
+#include <string>
+#include <span>
+
 constexpr int s2ns = 1000000000;
 constexpr int ns_precision = 9;
+
+/* Parse the value corresponding to given option. Return empty string if not found. */
+auto inline get_command_line_argument(const auto& args, const std::string& option) -> std::string
+{
+  size_t option_index = 0;
+  size_t args_size = static_cast<uint>(args.size());
+  for (; option_index < args_size; option_index++) {
+    if (args[option_index] == option) {
+      break;
+    }
+  }
+  if (option_index + 1 < args_size) {
+    return args[option_index + 1];
+  }
+  return {};
+}

--- a/controller/source/kv_client/factory.hpp
+++ b/controller/source/kv_client/factory.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string>
+
+#include "kv_client.hpp"
+#include "redis.hpp"
+#include "rocksdb.hpp"
+
+
+class kv_factory {
+  
+  /* Get default address for given kv_backend. */
+  static auto get_default_address(const std::string& kv_backend) -> std::string {
+    if (kv_backend == "redis") {
+      return "tcp://127.0.0.1:6379";
+    } 
+    if (kv_backend == "rocksdb") {
+      return "./db";
+    }
+    throw std::runtime_error("Unsupported KV backend");
+  }
+
+public:
+
+  kv_factory() = delete;
+
+  /* Create kv_client object with given kv_backend and address. */
+  static auto create(const std::string& kv_backend, std::string address) -> std::unique_ptr<kv_client> {
+    if (address.empty()) {
+      address = get_default_address(kv_backend);
+    }
+
+    std::cout << "Creating kv_client. Type: " << kv_backend << ", address: " << address << std::endl;
+
+    if (kv_backend == "redis") {
+      return std::make_unique<redis_client>(address);
+    } 
+    if (kv_backend == "rocksdb") {
+      return std::make_unique<rocksdb_client>(address);
+    }
+    std::cerr << "Unsupported KV backend: " << kv_backend << std::endl;
+    std::quick_exit(1);
+  }
+};

--- a/controller/source/kv_client/kv_client.hpp
+++ b/controller/source/kv_client/kv_client.hpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <string>
+#include <optional>
 
 class kv_client
 {

--- a/controller/source/native_controller.cpp
+++ b/controller/source/native_controller.cpp
@@ -2,15 +2,22 @@
 #include <string>
 #include <chrono>
 
-#include "kv_client/redis.hpp"
+#include "kv_client/factory.hpp"
 #include "query.hpp"
 #include "common.hpp"
 // #include "argh.hpp"
 
-auto main() -> int
+auto main(int argc, char* argv[]) -> int
 { 
   /* initialize the client object that exports put/get/delete API */
-  redis_client client("tcp://127.0.0.1:6379");
+  auto args = std::span(argv, static_cast<size_t>(argc));
+  std::string db_type = get_command_line_argument(args, "--db");
+  if (db_type.empty()) {
+    std::cerr << "--db {redis,rocksdb} argument is not passed!" << std::endl;
+    std::quick_exit(1);
+  }
+  std::string db_address = get_command_line_argument(args, "--address");
+  std::unique_ptr<kv_client> client = kv_factory::create(db_type, db_address);
   
   auto start = std::chrono::high_resolution_clock::now();
 
@@ -21,14 +28,14 @@ auto main() -> int
     std::cin >> command;
     if (command == "get") {
       std::cin >> key;
-      client.get(key);
+      client->get(key);
     } else if (command == "put") {
       std::cin >> key;
       std::cin >> value;
-      client.put(key, controller::get_value());
+      client->put(key, controller::get_value());
     } else if (command == "del") {
       std::cin >> key;
-      client.del(key);
+      client->del(key);
     } else if (command == "exit") {
       // std::cout << "Exiting..." << std::endl;
       break;

--- a/native_ctl.py
+++ b/native_ctl.py
@@ -1,66 +1,32 @@
-import sys
-import json
 import argparse
 import subprocess
-import pexpect
-import time
 import os
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-policy_compiler_dir = os.path.join(script_dir, './policy_compiler')
-sys.path.insert(1, policy_compiler_dir) # add the policy compiler in sys path
-from helper import safe_open
-from query_analyser import analyze_query
+from common import execute_queries, DbType
+
 
 # NOTE: we use send(str+"\n") to communicate with the process because the sendline() hangs with 0 delaybeforesend
 
 def main():
   parser = argparse.ArgumentParser(description='Start Native controller instance for a specific workload.')
-  parser.add_argument('-w', '--workload', help='path to the workload trace file', 
-                        dest='workload', default=None, nargs=1, required=True, type=str)
-  args = parser.parse_args(sys.argv[1:]) # to exclude the script name
+  parser.add_argument('--workload', help='path to the workload trace file', default=None, required=True, type=str)
+  parser.add_argument('--db', help='db to use, one of {rocksdb,redis}', default=DbType.ROCKSDB, required=False, type=DbType)
+  parser.add_argument('--address', help='db ip address for client to connect', default=None, required=False, type=str)
+  args = parser.parse_args()
 
-  workload_file = args.workload[0] # the file containing the queries to test
-  if "gdpr" in workload_file:
+  if "gdpr" in args.workload:
     print("please provide a non-gdpr workload for the native client")
     return
   
   # Open the controller process
-  exec_file = os.path.join(script_dir, './controller/build/native_controller')
-  controller = subprocess.Popen([exec_file], stdin=subprocess.PIPE, 
-                                            stdout=subprocess.PIPE, 
-                                            stderr=subprocess.PIPE)
-  # Start the time measurement before sending the workload
-  start_time = time.perf_counter_ns()
-
-  # Parse and send the query args to the native controller
-  workload_file = safe_open(workload_file, "r")
-  queries = workload_file.readlines()
-
-  for query in queries:
-    new_query = analyze_query(query.rstrip())
-    controller.stdin.write(new_query.encode() + b'\n')
-    controller.stdin.flush()
-
-  controller.stdin.write(b'exit\n')
-  controller.stdin.flush()
-
-  # Read process' standard output and error
-  output, error = controller.communicate()
-  controller.terminate()
-
-  # End the timer after the controller has returned and analyse the measurements
-  end_time = time.perf_counter_ns()
-  runtime = end_time - start_time
-
-  # Print the output of the controller process
-  if error:
-    print(error.decode('utf-8'))
-  print(output.decode('utf-8'), end = '')
-
-  # Print the timer results
-  seconds = runtime / 1000000000
-  print("System time: {:.9f} s".format(seconds))
+  process_args = [os.path.join(os.path.dirname(os.path.abspath(__file__)), './controller/build/native_controller')]
+  process_args += ['--db', args.db]
+  if args.address:
+    process_args += ['--address', args.address]
+  controller = subprocess.Popen(process_args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+  
+  # Execute queries
+  execute_queries(controller, args.workload)
 
   return
 

--- a/policy_compiler/policy_config.py
+++ b/policy_compiler/policy_config.py
@@ -1,6 +1,6 @@
 import sys
 import json
-from helper import safe_open
+from policy_compiler.helper import safe_open
 import argparse
 
 mandatory_keys = ["sessionKey", "default_policy"]

--- a/policy_compiler/query_analyser.py
+++ b/policy_compiler/query_analyser.py
@@ -1,7 +1,7 @@
 import sys
 import json
-from helper import safe_open
-from KV_interface import rewrite_query
+from policy_compiler.helper import safe_open
+from policy_compiler.KV_interface import rewrite_query
 import argparse
 
 policy_predicates = [

--- a/ycsb_trace_generator/workload_generator.sh
+++ b/ycsb_trace_generator/workload_generator.sh
@@ -11,7 +11,7 @@ mvn clean package
 popd
 
 ### set and create the traces folder if it doesn't exist
-TRACE_FOLDER=/home/dimitrios/GDPRuler/workload_traces
+TRACE_FOLDER=${SCRIPT_DIR}/../workload_traces
 mkdir -p ${TRACE_FOLDER}
 echo "Trace file directory: ${TRACE_FOLDER}" 
 


### PR DESCRIPTION
**Changes:**
- added --db {rocksdb,redis} option to both python scripts and to both controllers. This argument is required.
- added --address <db_address: string> option to both python scripts and to both controllers. This argument is optional. If not passed, default addresses will be used.
- refactored python scripts. pulled some of the common functionality in `native_ctl.py` and `GDPRuler.py` into `common.py`.

**Testing:**

- Tested both `native` and `gdpr` controllers with python scripts using both `rocksdb` and `redis` clients. Used workload f.