### PR TITLE
implement rocksdb tcp server and update client

### DIFF
--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -45,6 +45,9 @@ find_library(REDIS_PLUS_PLUS_LIB redis++)
 # find_path(ROCKSDB_HEADER rocksdb)
 find_library(ROCKSDB_LIB rocksdb)
 
+# ---- Add boost dependency ----
+find_package(Boost REQUIRED COMPONENTS system)
+
 # ---- Declare executables ----
 
 # main
@@ -55,7 +58,7 @@ set_property(TARGET gdpr_controller_exe PROPERTY OUTPUT_NAME gdpr_controller)
 
 target_compile_features(gdpr_controller_exe PRIVATE cxx_std_20)
 
-target_link_libraries(gdpr_controller_exe PRIVATE gdpr_controller_lib ${HIREDIS_LIB} ${REDIS_PLUS_PLUS_LIB} ${ROCKSDB_LIB})
+target_link_libraries(gdpr_controller_exe PRIVATE gdpr_controller_lib ${HIREDIS_LIB} ${REDIS_PLUS_PLUS_LIB} ${ROCKSDB_LIB} ${Boost_LIBRARIES})
 
 # native controller
 add_executable(native_controller_exe source/native_controller.cpp)
@@ -65,7 +68,7 @@ set_property(TARGET native_controller_exe PROPERTY OUTPUT_NAME native_controller
 
 target_compile_features(native_controller_exe PRIVATE cxx_std_20)
 
-target_link_libraries(native_controller_exe PRIVATE ${HIREDIS_LIB} ${REDIS_PLUS_PLUS_LIB} ${ROCKSDB_LIB})
+target_link_libraries(native_controller_exe PRIVATE ${HIREDIS_LIB} ${REDIS_PLUS_PLUS_LIB} ${ROCKSDB_LIB} ${Boost_LIBRARIES})
 
 # redis interface
 add_executable(redis_interface_exe source/redis_interface.cpp)
@@ -77,6 +80,16 @@ target_compile_features(redis_interface_exe PRIVATE cxx_std_20)
 
 target_link_libraries(redis_interface_exe PRIVATE gdpr_controller_lib ${HIREDIS_LIB} ${REDIS_PLUS_PLUS_LIB})
 target_include_directories(redis_interface_exe SYSTEM PRIVATE ${HIREDIS_HEADER} ${REDIS_PLUS_PLUS_HEADER})
+
+# rocksdb server
+add_executable(rocksdb_server_exe source/rocksdb_server/server.cpp)
+add_executable(rocksdb_server::exe ALIAS rocksdb_server_exe)
+
+set_property(TARGET rocksdb_server_exe PROPERTY OUTPUT_NAME rocksdb_server)
+
+target_compile_features(rocksdb_server_exe PRIVATE cxx_std_20)
+
+target_link_libraries(rocksdb_server_exe PRIVATE ${Boost_LIBRARIES} ${ROCKSDB_LIB})
 
 # ---- Install rules ----
 

--- a/controller/source/kv_client/factory.hpp
+++ b/controller/source/kv_client/factory.hpp
@@ -15,7 +15,7 @@ class kv_factory {
       return "tcp://127.0.0.1:6379";
     } 
     if (kv_backend == "rocksdb") {
-      return "./db";
+      return "127.0.0.1:15001";
     }
     throw std::runtime_error("Unsupported KV backend");
   }

--- a/controller/source/kv_client/rocksdb.hpp
+++ b/controller/source/kv_client/rocksdb.hpp
@@ -1,65 +1,93 @@
 #pragma once
 
-#include <rocksdb/db.h>
-#include <rocksdb/options.h>
+#include <vector>
 
+#include <boost/algorithm/string.hpp>
+#include <boost/asio.hpp>
+
+#include "../rocksdb_server/message.hpp"
 #include "kv_client.hpp"
 
 class rocksdb_client : public kv_client
 {
-rocksdb::DB* m_rocksdb{nullptr};
-
 public:
-  explicit rocksdb_client(const std::string& db_path) {
-    rocksdb::Options options;
-    options.create_if_missing = true;
-    rocksdb::Status status = rocksdb::DB::Open(options, db_path, &m_rocksdb);
-    if (!status.ok()) {
-      std::cerr << "Failed to open database: " << status.ToString() << std::endl;
-    }
+  explicit rocksdb_client(const std::string& addr)
+      : m_socket(m_io_context)
+  {
+    std::vector<std::string> host_port_splits;
+    boost::split(host_port_splits, addr, boost::is_any_of(":"));
+    assert(host_port_splits.size() == 2 && "DB server address must be in <host>:<port> format!");
+
+    // Resolve the host and port to an endpoint
+    using boost::asio::ip::tcp;
+    tcp::resolver resolver(m_io_context);
+    tcp::resolver::results_type endpoints = resolver.resolve(host_port_splits[0], host_port_splits[1]);
+
+    boost::asio::connect(m_socket, endpoints);
   }
 
   auto get(const std::string& key) -> std::optional<std::string> override
   {
-    std::string value;
-    rocksdb::Status status = m_rocksdb->Get(rocksdb::ReadOptions(), key, &value);
-    if (status.ok()) {
-      std::cout << "GET operation succeeded! Key: " << key << ", Value: " << value << std::endl;
+    query_message query;
+    query.set_command("get");
+    query.set_key(key);
+    query.set_is_valid(/*is_valid*/true);
+
+    response_message response = execute(query);
+    if (response.get_is_success()) {
+      // std::cout << "GET operation succeeded! Key: " << key << ", Value: " << response.response << std::endl;
     } else {
       std::cout << "GET operation failed" << std::endl;
     }
-    return value;
+    return response.get_data();
   }
 
   auto put(const std::string& key, const std::string& value) -> bool override
   {
-    rocksdb::Status status = m_rocksdb->Put(rocksdb::WriteOptions(), key, value);
-    if (status.ok()) {
-      std::cout << "PUT operation succeeded! Key: " << key << ", Value: " << value << std::endl;
+    query_message query;
+    query.set_command("put");
+    query.set_key(key);
+    query.set_value(value);
+    query.set_is_valid(/*is_valid*/true);
+
+    response_message response = execute(query);
+    if (response.get_is_success()) {
+      // std::cout << "PUT operation succeeded! Key: " << key << ", Value: " << value << std::endl;
     } else {
       std::cout << "PUT operation failed" << std::endl;
     }
-    return status.ok();
+    return response.get_is_success();
   }
 
   auto del(const std::string& key) -> bool override
   {
-    rocksdb::Status status = m_rocksdb->Delete(rocksdb::WriteOptions(), key);
-    if (status.ok()) {
-      std::cout << "DELETE operation succeeded! Key: " << key << std::endl;
+    query_message query;
+    query.set_command("del");
+    query.set_key(key);
+    query.set_is_valid(/*is_valid*/true);
+
+    response_message response = execute(query);
+    if (response.get_is_success()) {
+      // std::cout << "DELETE operation succeeded! Key: " << key << std::endl;
     } else {
       std::cout << "DELETE operation failed" << std::endl;
     }
-    return status.ok();
+    return response.get_is_success();
   }
 
-  ~rocksdb_client() override {
-    delete m_rocksdb;
-  }
+private:
+  boost::asio::io_context m_io_context;
+  boost::asio::ip::tcp::socket m_socket;
 
-  rocksdb_client() = default;
-  rocksdb_client(const rocksdb_client&) = default;
-  auto operator=(rocksdb_client const&) -> rocksdb_client& = default;
-  rocksdb_client(rocksdb_client&&) = default;
-  auto operator=(rocksdb_client&&) -> rocksdb_client& = default;
+  auto execute(query_message query) -> response_message
+  {
+    std::string raw_query = query.serialize();
+    boost::asio::write(m_socket, boost::asio::buffer(raw_query));
+
+    // Receive a response from the server
+    boost::asio::streambuf receive_buffer;
+    boost::asio::read_until(m_socket, receive_buffer, "\n");
+    std::string raw_response(boost::asio::buffers_begin(receive_buffer.data()), boost::asio::buffers_end(receive_buffer.data()) - 1);
+    return response_message::deserialize(raw_response);
+  }
 };

--- a/controller/source/kv_client/rocksdb.hpp
+++ b/controller/source/kv_client/rocksdb.hpp
@@ -42,6 +42,8 @@ public:
     return response.get_data();
   }
 
+  // To suppress bugprone-easily-swappable-parameters warning from clang-tidy
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   auto put(const std::string& key, const std::string& value) -> bool override
   {
     query_message query;

--- a/controller/source/rocksdb_server/README.md
+++ b/controller/source/rocksdb_server/README.md
@@ -1,0 +1,25 @@
+# rocksdb_server
+
+This directory contains the source code of a TCP based rocksdb server. 
+
+## How to run server
+
+Program binary can be built alongside the gdpr_controller CMake. The rocksdb server is a standalone CLI program which can be executed with "./rocksdb_server <listening_port> <rocksdb_storage_path> <n_handler_threads>" command. Note that it expects exactly three arguments in this order.
+
+Example execution: **./rocksdb_server 15001 ./db 2**
+
+## File definitions
+
+* message.hpp file contains the expected request and response message protocols.
+* rocksdb_proxy.hpp file contains an interface to interact with the actual rocksdb library.
+* server.cpp file contains the entry point to the program. Using boost::asio library, it listens to the connections and serve them.
+
+## How to test server
+
+1. Using netcat on terminal: 
+    1. Start rocksdb_server using above command.
+    2. Execute: **nc localhost 15001** command to have an interactive tcp connection
+    3. Type queries and see responses. (Example: "put 5 15", "get 5", "del 5", ...)
+2. Using Python scripts and workloads:
+    1. Start rocksdb_server using above command.
+    2. Execute: **python GDPRuler.py --config ./configs/owner_policy.json --workload ./workload_traces/workloadf_test --db rocksdb --address 127.0.0.1:15001**

--- a/controller/source/rocksdb_server/README.md
+++ b/controller/source/rocksdb_server/README.md
@@ -4,9 +4,9 @@ This directory contains the source code of a TCP based rocksdb server.
 
 ## How to run server
 
-Program binary can be built alongside the gdpr_controller CMake. The rocksdb server is a standalone CLI program which can be executed with "./rocksdb_server <listening_port> <rocksdb_storage_path> <n_handler_threads>" command. Note that it expects exactly three arguments in this order.
+Program binary can be built alongside the gdpr_controller CMake. The rocksdb server is a standalone CLI program which can be executed with "./rocksdb_server <listening_port> <rocksdb_storage_path>" command. Note that it expects exactly two arguments in this order.
 
-Example execution: **./rocksdb_server 15001 ./db 2**
+Example execution: **./rocksdb_server 15001 ./db**
 
 ## File definitions
 

--- a/controller/source/rocksdb_server/message.hpp
+++ b/controller/source/rocksdb_server/message.hpp
@@ -118,7 +118,7 @@ private:
  * 
  * The raw message contains two fields: is_success, data.
  * is_success represents the result of an operation.
- * data represents the value retrieved in case of a successful put operation, 
+ * data represents the value retrieved in case of a successful get operation, 
  *  or the response message otherwise.
  * 
  * Expected message protocol: "<status:{success,failure}>: <data>"

--- a/controller/source/rocksdb_server/message.hpp
+++ b/controller/source/rocksdb_server/message.hpp
@@ -7,6 +7,19 @@
 #include <boost/algorithm/string.hpp>
 
 
+/**
+ * query_message is the expected message protocol sent from clients to the server.
+ * 
+ * The raw message contains three fields: command, key, and value.
+ * is_valid field is populated after receiving and parsing the raw message.
+ * 
+ * Expected message protocol: "<command> <key> <value>"
+ * 
+ * Example query_messages         || Their meanings
+ *  "del key_to_delete"           -> delete the entry with key "key_to_delete"
+ *  "get key_to_get"              -> get the entry with key "key_to_get"
+ *  "put key_to_put value_to_put" -> put entry with {"key_to_put": "value_to_put"}
+*/
 class query_message
 {
 public:
@@ -99,6 +112,22 @@ private:
   bool m_is_valid {false};
 };
 
+
+/**
+ * response_message is the expected message protocol sent from server to clients.
+ * 
+ * The raw message contains two fields: is_success, data.
+ * is_success represents the result of an operation.
+ * data represents the value retrieved in case of a successful put operation, 
+ *  or the response message otherwise.
+ * 
+ * Expected message protocol: "<status:{success,failure}>: <data>"
+ * 
+ * Example query_messages         || Their meanings
+ *  "success: del succeeded"      -> delete the entry with key "key_to_delete"
+ *  "failure: get failed"         -> get operation failed
+ *  "success: value_retrieved"    -> get operation succeded and value corresponding to key is "value_retrieved"
+*/
 class response_message
 {
 public:

--- a/controller/source/rocksdb_server/message.hpp
+++ b/controller/source/rocksdb_server/message.hpp
@@ -123,8 +123,10 @@ public:
   {
     static response_message invalid_response {/*is_success=*/false, "invalid"};
     static std::unordered_set<std::string> valid_response_types {"success", "failure"};
+    static const std::string response_message_delimiter = ": ";
+    static const size_t response_message_delimiter_len = response_message_delimiter.size();
 
-    size_t index = raw_query.find(": ");
+    size_t index = raw_query.find(response_message_delimiter);
     if (index == std::string::npos) {
       return invalid_response;
     }
@@ -134,7 +136,7 @@ public:
       return invalid_response;
     }
 
-    std::string second_str = raw_query.substr(index + 2, raw_query.size());
+    std::string second_str = raw_query.substr(index + response_message_delimiter_len, raw_query.size());
     return response_message {first_str == "success", second_str};
   }
 

--- a/controller/source/rocksdb_server/message.hpp
+++ b/controller/source/rocksdb_server/message.hpp
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+#include <boost/algorithm/string.hpp>
+
+
+class query_message
+{
+public:
+  query_message() = default;
+
+  auto serialize() -> std::string
+  {
+    std::string result;
+    result.append(m_command).append(" ").append(m_key);
+    if (!m_value.empty()) {
+      result.append(" ").append(m_value);
+    }
+    result.append("\n");
+    return result;
+  }
+
+  static auto deserialize(const std::string& raw_query) -> query_message
+  {
+    static query_message invalid_query;
+    static std::unordered_set<std::string> valid_query_types {"get", "put", "del"};
+
+    std::vector<std::string> splits;
+    boost::split(splits, raw_query, boost::is_any_of(" "));
+
+    if (splits.size() < 2) {
+      std::cout << "Invalid query message. Minimum 2 arguments needed."
+                << std::endl;
+      return invalid_query;
+    }
+
+    if (!valid_query_types.contains(splits[0])) {
+      std::cout
+          << "Invalid query type. A valid query can be one of {get, put, del}"
+          << std::endl;
+      return invalid_query;
+    }
+
+    if (splits[0] == "put" && splits.size() != 3) {
+      std::cout << "Invalid query. put query expects exactly 3 arguments."
+                << std::endl;
+      return invalid_query;
+    }
+
+    query_message result;
+    result.m_command = splits[0];
+    result.m_key = splits[1];
+    if (splits.size() == 3) {
+      result.m_value = splits[2];
+    }
+    result.m_is_valid = true;
+    return result;
+  }
+
+  auto get_command() -> std::string {
+    return m_command;
+  }
+
+  void set_command(const std::string& command) {
+    m_command = command;
+  }
+
+  auto get_key() -> std::string {
+    return m_key;
+  }
+
+  void set_key(const std::string& key) {
+    m_key = key;
+  }
+
+  auto get_value() -> std::string {
+    return m_value;
+  }
+
+  void set_value(const std::string& value) {
+    m_value = value;
+  }
+
+  auto get_is_valid() const -> bool {
+    return m_is_valid;
+  }
+
+  void set_is_valid(bool is_valid) {
+    m_is_valid = is_valid;
+  }
+  
+private:
+  std::string m_command;
+  std::string m_key;
+  std::string m_value;
+  bool m_is_valid {false};
+};
+
+class response_message
+{
+public:
+  response_message() = default;
+
+  response_message(bool is_success, std::string data)
+      : m_is_success {is_success}
+      , m_data {std::move(data)}
+  {
+  }
+
+  auto serialize() -> std::string
+  {
+    std::string result;
+    result.append(m_is_success ? "success: " : "failure: ")
+        .append(m_data)
+        .append("\n");
+    return result;
+  }
+
+  static auto deserialize(const std::string& raw_query) -> response_message
+  {
+    static response_message invalid_response {/*is_success=*/false, "invalid"};
+    static std::unordered_set<std::string> valid_response_types {"success", "failure"};
+
+    size_t index = raw_query.find(": ");
+    if (index == std::string::npos) {
+      return invalid_response;
+    }
+
+    std::string first_str = raw_query.substr(0, index);
+    if (!valid_response_types.contains(first_str)) {
+      return invalid_response;
+    }
+
+    std::string second_str = raw_query.substr(index + 2, raw_query.size());
+    return response_message {first_str == "success", second_str};
+  }
+
+  auto get_is_success() const -> bool {
+    return m_is_success;
+  }
+
+  auto get_data() -> std::string {
+    return m_data;
+  }
+
+private:
+  bool m_is_success {false};
+  std::string m_data;
+};

--- a/controller/source/rocksdb_server/rocksdb_proxy.hpp
+++ b/controller/source/rocksdb_server/rocksdb_proxy.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <iostream>
+#include <optional>
+
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+
+#include "message.hpp"
+
+class rocksdb_proxy
+{
+public:
+  explicit rocksdb_proxy(const std::string& db_path)
+  {
+    rocksdb::Options options;
+    options.create_if_missing = true;
+    rocksdb::Status status = rocksdb::DB::Open(options, db_path, &m_rocksdb);
+    if (!status.ok()) {
+      std::cerr << "Failed to open database: " << status.ToString()
+                << std::endl;
+    }
+  }
+
+  auto execute(query_message query) -> response_message 
+  {
+    if (!query.get_is_valid()) {
+      return response_message{/*is_success*/false, "invalid query"};
+    }
+
+    if (query.get_command() == "get") {
+      return get(query.get_key());
+    }
+    if (query.get_command() == "put") {
+      return put(query.get_key(), query.get_value());
+    }
+    return del(query.get_key());
+  }
+
+  ~rocksdb_proxy() { delete m_rocksdb; }
+
+  rocksdb_proxy() = default;
+  rocksdb_proxy(const rocksdb_proxy&) = default;
+  auto operator=(rocksdb_proxy const&) -> rocksdb_proxy& = default;
+  rocksdb_proxy(rocksdb_proxy&&) = default;
+  auto operator=(rocksdb_proxy&&) -> rocksdb_proxy& = default;
+
+private:
+  rocksdb::DB* m_rocksdb {nullptr};
+
+  auto get(const std::string& key) -> response_message
+  {
+    std::string value;
+    rocksdb::Status status =
+        m_rocksdb->Get(rocksdb::ReadOptions(), key, &value);
+    if (status.ok()) {
+      return response_message{/*is_success*/true, value};
+    }
+    return response_message{/*is_success*/false, "get failed"};
+  }
+
+  auto put(const std::string& key, const std::string& value) -> response_message
+  {
+    rocksdb::Status status =
+        m_rocksdb->Put(rocksdb::WriteOptions(), key, value);
+    if (status.ok()) {
+      return response_message{/*is_success*/true, "put succeeded"};
+    } 
+    return response_message{/*is_success*/false, "put failed"};
+  }
+
+  auto del(const std::string& key) -> response_message
+  {
+    rocksdb::Status status = m_rocksdb->Delete(rocksdb::WriteOptions(), key);
+    if (status.ok()) {
+      return response_message{/*is_success*/true, "del succeeded"};
+    } 
+    return response_message{/*is_success*/false, "del failed"};
+  }
+};

--- a/controller/source/rocksdb_server/rocksdb_proxy.hpp
+++ b/controller/source/rocksdb_server/rocksdb_proxy.hpp
@@ -8,6 +8,9 @@
 
 #include "message.hpp"
 
+/**
+ * rocksdb_proxy is a wrapper to interact with the rocksdb.
+*/
 class rocksdb_proxy
 {
 public:

--- a/controller/source/rocksdb_server/server.cpp
+++ b/controller/source/rocksdb_server/server.cpp
@@ -91,6 +91,7 @@ private:
     });
   }
 
+  // tcp connection acceptor to asynchronously accept the connections and delegate the handling to sessions
   tcp::acceptor m_acceptor;
   tcp::socket m_socket;
   std::shared_ptr<rocksdb_proxy> m_rocksdb_proxy;
@@ -101,8 +102,14 @@ auto main(int argc, char* argv[]) -> int {
 
   try {
     assert(argc == 3 && "Usage: ./rocksdb_server <port> <db_path>");
+
+    // io_service is the entry point to use boost's async capabilities. It is an interface to the OS I/O services.
+    // It manages the threads and the event loop related to connections and handler callbacks. 
+    // See here for more info: https://www.boost.org/doc/libs/1_65_1/doc/html/boost_asio/overview/core/basics.html 
     boost::asio::io_service io_service;
     rocksdb_server rocksdb_server(io_service, static_cast<uint16_t>(std::stoul(args[1])), args[2]);
+
+    // run() method is used to dequeue the async operation results and call the respective handlers.
     io_service.run();
   } catch (std::exception& e) {
     std::cerr << "Exception in Rocksdb server: " << e.what() << std::endl;

--- a/controller/source/rocksdb_server/server.cpp
+++ b/controller/source/rocksdb_server/server.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 #include <boost/asio.hpp>
+#include <thread>
 
 #include "rocksdb_proxy.hpp"
 
@@ -101,16 +102,26 @@ auto main(int argc, char* argv[]) -> int {
   auto args = std::span(argv, static_cast<size_t>(argc));
 
   try {
-    assert(argc == 3 && "Usage: ./rocksdb_server <port> <db_path>");
+    assert(argc == 4 && "Usage: ./rocksdb_server <port> <db_path> <n_threads>");
 
     // io_service is the entry point to use boost's async capabilities. It is an interface to the OS I/O services.
     // It manages the threads and the event loop related to connections and handler callbacks. 
     // See here for more info: https://www.boost.org/doc/libs/1_65_1/doc/html/boost_asio/overview/core/basics.html 
     boost::asio::io_service io_service;
     rocksdb_server rocksdb_server(io_service, static_cast<uint16_t>(std::stoul(args[1])), args[2]);
+    size_t n_threads = std::stoul(args[3]);
+    std::vector<std::thread> handler_threads(n_threads);
 
-    // run() method is used to dequeue the async operation results and call the respective handlers.
-    io_service.run();
+    // start handler threads
+    for (size_t i = 0; i < n_threads; i++) {
+      // run() method is used to dequeue the async operation results and call the respective handlers.
+      handler_threads[i] = std::thread {[&io_service]() {io_service.run();} };
+    }
+
+    // join handler threads
+    for (size_t i = 0; i < n_threads; i++) {
+      handler_threads[i].join();
+    }
   } catch (std::exception& e) {
     std::cerr << "Exception in Rocksdb server: " << e.what() << std::endl;
     return 1;

--- a/controller/source/rocksdb_server/server.cpp
+++ b/controller/source/rocksdb_server/server.cpp
@@ -29,7 +29,7 @@ private:
       if (!error_code) {
         // put buffered data into string excluding the last new line character
         auto buffer_begin = boost::asio::buffers_begin(m_buffer.data());
-        std::string raw_query(buffer_begin, buffer_begin + length - 1);
+        std::string raw_query(buffer_begin, buffer_begin + static_cast<int>(length) - 1);
         m_buffer.consume(length);
         query_message query = query_message::deserialize(raw_query);
         response_message response = m_rocksdb_proxy->execute(query);

--- a/controller/source/rocksdb_server/server.cpp
+++ b/controller/source/rocksdb_server/server.cpp
@@ -22,6 +22,8 @@ public:
   }
 
 private:
+  // handle_read() makes use of boost asio and it needs to call itself again to process the next chunk received.
+  // NOLINTBEGIN(misc-no-recursion)
   void handle_read() {
     auto self(shared_from_this());
     boost::asio::async_read_until(m_socket, m_buffer, '\n',
@@ -45,6 +47,7 @@ private:
       }
     });
   }
+  // NOLINTEND(misc-no-recursion)
 
   tcp::socket m_socket;
   std::shared_ptr<rocksdb_proxy> m_rocksdb_proxy;

--- a/controller/source/rocksdb_server/server.cpp
+++ b/controller/source/rocksdb_server/server.cpp
@@ -1,0 +1,95 @@
+#include <iostream>
+#include <string>
+#include <span>
+#include <vector>
+#include <memory>
+#include <boost/asio.hpp>
+
+#include "rocksdb_proxy.hpp"
+
+using boost::asio::ip::tcp;
+
+class session : public std::enable_shared_from_this<session> {
+public:
+  session(tcp::socket socket, std::shared_ptr<rocksdb_proxy> rocksdb_proxy)
+      : m_socket(std::move(socket))
+      , m_rocksdb_proxy(std::move(rocksdb_proxy))
+  {
+  }
+
+  void start() {
+    do_read();
+  }
+
+private:
+  void do_read() {
+    auto self(shared_from_this());
+    boost::asio::async_read_until(m_socket, m_buffer, '\n',
+      [this, self](boost::system::error_code error_code, std::size_t length) {
+      if (!error_code) {
+        // put buffered data into string excluding the last new line character
+        std::string raw_query(boost::asio::buffers_begin(m_buffer.data()), boost::asio::buffers_end(m_buffer.data()) - 1);
+        m_buffer.consume(length);
+        query_message query = query_message::deserialize(raw_query);
+        response_message response = m_rocksdb_proxy->execute(query);
+        std::string raw_response = response.serialize();
+        boost::asio::write(m_socket, boost::asio::buffer(raw_response));
+        do_read();
+      }
+      else if (error_code == boost::asio::error::eof) {
+        std::cout << "Client is finished with the queries. Closing the session..." << std::endl;
+      }
+      else {
+        std::cout << "Error while reading tcp message: " << error_code << std::endl;
+      }
+    });
+  }
+
+  tcp::socket m_socket;
+  std::shared_ptr<rocksdb_proxy> m_rocksdb_proxy;
+  boost::asio::streambuf m_buffer;
+};
+
+class rocksdb_server {
+public:
+  rocksdb_server(boost::asio::io_service& io_service,
+                 uint16_t port,
+                 const std::string& db_path)
+      : m_acceptor(io_service, tcp::endpoint(tcp::v4(), port))
+      , m_socket(io_service)
+      , m_rocksdb_proxy(make_shared<rocksdb_proxy>(db_path))
+  {
+    std::cout << "Starting server on port: " << port << std::endl;
+    do_accept();
+  }
+
+private:
+  void do_accept() {
+    std::cout << "Server is waiting to accept a new request!" << std::endl;
+    m_acceptor.async_accept(m_socket, [this](boost::system::error_code error_code) {
+      if (!error_code) {
+        std::make_shared<session>(std::move(m_socket), m_rocksdb_proxy)->start();
+      }
+      do_accept();
+    });
+  }
+
+  tcp::acceptor m_acceptor;
+  tcp::socket m_socket;
+  std::shared_ptr<rocksdb_proxy> m_rocksdb_proxy;
+};
+
+auto main(int argc, char* argv[]) -> int {
+  auto args = std::span(argv, static_cast<size_t>(argc));
+
+  try {
+    assert(argc == 3 && "Usage: ./rocksdb_server <port> <db_path>");
+    boost::asio::io_service io_service;
+    rocksdb_server rocksdb_server(io_service, static_cast<uint16_t>(std::stoul(args[1])), args[2]);
+    io_service.run();
+  } catch (std::exception& e) {
+    std::cerr << "Exception in Rocksdb server: " << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/controller/source/rocksdb_server/server.cpp
+++ b/controller/source/rocksdb_server/server.cpp
@@ -9,6 +9,12 @@
 
 using boost::asio::ip::tcp;
 
+/**
+ * session class represents a connection handler for a single client.
+ * 
+ * Given a socket and a rocksdb_proxy, 
+ *  it listens the socket asynchronously, parses the requests, executes them, and writes back proper response messages.
+*/
 class session : public std::enable_shared_from_this<session> {
 public:
   session(tcp::socket socket, std::shared_ptr<rocksdb_proxy> rocksdb_proxy)
@@ -54,6 +60,13 @@ private:
   boost::asio::streambuf m_buffer;
 };
 
+/**
+ * rocksdb_server is the external interface to the outside world on a tcp port.
+ * 
+ * It initializes the db startup, accepts the client requests asynchronously over tcp sockets, 
+ *  delegates the handling of them to individual sessions.
+ *  
+*/
 class rocksdb_server {
 public:
   rocksdb_server(boost::asio::io_service& io_service,

--- a/default.nix
+++ b/default.nix
@@ -51,6 +51,7 @@ mkShell {
     snappy
     zlib
     gflags
+    boost
 
     #GDPRBench specific packages
     maven


### PR DESCRIPTION
**Changes**

- Rocksdb server is implemented which gets requests from multiple clients concurrently over tcp. Boost async io library is used.
- Rocksdb client is updated in controllers. Boost tcp client is used.

**Notes**

- There is a warning due to recursion in `do_read` method [here](https://github.com/dimstav23/GDPRuler/compare/separate-rocksdb-client-server?expand=1#diff-52aa306fcfb9d7b567403b0bc3631bccb1008c5a7b20fb14663144d8ec2b4bbaR37). I think it is unavoidable if we use boost lib since the callback we bind should be called multiple times before closing a connection. Otherwise, only a part of the stream is received. Please let me know if there is a way to avoid this.

**Tests**

- Tested with workloads a-d and f. All of them are working with both `native` and `gdpr` controllers.
- Tested multiple workloads simultaneously - no problems.