### PR TITLE
Setup and documentation of AMD SEV SNP  VMs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "ycsb_trace_generator/GDPRbench"]
 	path = ycsb_trace_generator/GDPRbench
 	url = https://github.com/dimstav23/GDPRbench.git
+[submodule "AMD_SEV_SNP/linux-svsm"]
+	path = AMD_SEV_SNP/linux-svsm
+	url = https://github.com/dimstav23/linux-svsm.git

--- a/AMD_SEV_SNP/README.md
+++ b/AMD_SEV_SNP/README.md
@@ -1,0 +1,102 @@
+# Steps to enable and launch an ubuntu-based SEV-SNP guest (applied in our NixOs servers - TUM Cluster) :
+
+### BIOS preparation
+- You have to enable the SME and SNP options in your BIOS settings.
+To do so in [`ryan`](https://github.com/TUM-DSE/doctor-cluster-config/blob/master/docs/hosts/ryan.md) and 
+[`graham`](https://github.com/TUM-DSE/doctor-cluster-config/blob/master/docs/hosts/graham.md),
+access their mgmt interface via ssh and run the following:
+```
+set BIOS.ProcSettings.Sme Enabled
+set BIOS.ProcSettings.Snp Enabled
+jobqueue create BIOS.Setup.1-1
+```
+and then reboot the server.
+- For SEV ES you have to enable IOMMU support and set the minimum SEV ASIDs value in the BIOS.
+To do so in [`ryan`](https://github.com/TUM-DSE/doctor-cluster-config/blob/master/docs/hosts/ryan.md) and 
+[`graham`](https://github.com/TUM-DSE/doctor-cluster-config/blob/master/docs/hosts/graham.md), 
+run the following after accessing their mgmt interface:
+```
+set BIOS.ProcSettings.IommuSupport Enabled
+set BIOS.ProcSettings.CpuMinSevAsid 128
+jobqueue create BIOS.Setup.1-1
+```
+and then reboot the server.
+For more information regarding the parameter for CPU mininmum SEV ASIDs specifically in our machines,
+look [here](https://www.dell.com/support/manuals/en-us/idrac9-lifecycle-controller-v4.x-series/idrac_4.00.00.00_racadm_ar_referenceguide/bios.procsettings.cpuminsevasid-(read-or-write)?guid=guid-4bdaeaa7-d054-4fd1-bd84-0cd71d7aec1e&lang=en-us).
+
+### 1. Use the dedicated host kernel and enable SEV-SNP in the desired server:
+Import the [amd_sev_snp.nix](https://github.com/TUM-DSE/doctor-cluster-config/blob/master/modules/amd_sev_snp.nix) module in the server configuration. 
+An example configuration is shown [here](https://github.com/TUM-DSE/doctor-cluster-config/blob/master/hosts/ryan.nix). 
+
+This module sets the appropriate kernel version and parameters, and adds the mandatory kernel modules for SME and SEV-SNP.
+
+**Note:** this setup has been tested with kernel `5.19-rc6` sev-snp version provided by AMD, with binutils patches.
+You can find the kernel [here](https://github.com/mmisono/linux/tree/sev-snp-iommu-avic_5.19-rc6_v4-dev).
+
+### 2. Verify that SME, SEV and SEV-ES are enabled:
+- `dmesg | grep SME` should indicate `AMD Memory Encryption Features active: SME` and
+- `dmesg | grep sev` should include `sev enabled` in its output.
+- `dmesg | grep -i SEV-ES` should indicate that `SEV-ES` is supported and the number of SEV ASIDs.
+- `dmesg | grep -i SEV-SNP` should indicate that `SEV-SNP` is enabled and the number of ASIDs.
+
+### 3. Prepare the host toolchain
+Compile the custom OVMF and QEMU provided by AMD:
+```
+$ cd linux-svsm/scripts
+$ ./build.sh qemu
+$ ./build.sh ovmf
+```
+
+### 4. Prepare an AMD SEV-SNP guest.
+You need to have cloud-config file and a network-config file for your VM, similar to those in the [cloud_configs](./cloud_configs/) folder.
+Follow the next set of commands to launch an SEV-SNP guest (tested with ubuntu 22.04 cloud img).
+```
+$ wget https://cloud-images.ubuntu.com/kinetic/current/kinetic-server-cloudimg-amd64.img 
+
+$ mkdir images
+
+$ sudo ./linux-svsm/scripts/usr/local/bin/qemu-img convert kinetic-server-cloudimg-amd64.img ./images/sev-server.img
+
+$ sudo ./linux-svsm/scripts/usr/local/bin/qemu-img resize ./images/sev-server.img +20G 
+
+$ ./prepare_net_cfg.sh virbr0 ./cloud_configs/network-config-server.yml
+
+$ sudo cloud-localds -N ./cloud_configs/network-config-server.yml ./images/server-cloud-config.iso ./cloud_configs/cloud-config-server
+
+$ cp /linux-svsm/scripts/usr/local/share/qemu/OVMF_CODE.fd ./OVMF_CODE_server.fd
+
+$ cp /linux-svsm/scripts/usr/local/share/qemu/OVMF_VARS.fd ./OVMF_VARS_client.fd
+```
+
+**Important note:** 
+- The [`prepare_net_cfg.sh`](./prepare_net_cfg.sh) script takes as a parameter the virtual bridge where the VMs will be connected to and modifies the IP prefix in the network configuration (given as a secord parameter) appropriately.
+- Each VM requires a separate `.img` and `OVMF_*.fd` files.
+
+### 5. Launch an AMD SEV-SNP guest.
+```
+$ sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH ./launch-qemu.sh 
+-hda ./images/sev-server.img \
+-cdrom ./images/server-cloud-config.iso \
+-sev-snp \
+-bridge virbr0 \
+-bios ./OVMF_CODE_server.fd \
+-bios-vars ./OVMF_VARS_server.fd
+```
+
+**Important note:** 
+- Follow the same process for the creation of a client vm (if you want/need to).
+You need a different `.img`, and to adapt the network configuration appropriately to reserve a different IP.
+Configuration examples are given in the [cloud_configs](./cloud_configs/) folder.
+
+### 6. Inside the guest VM, verify that AMD SEV-SNP is enabled:
+`sudo dmesg | grep snp -i ` should indicate `Memory Encryption Features active: AMD SEV SEV-ES SEV-SNP`
+
+### 7. Networking: 
+In step 5 above, we use the parameter `-bridge virbr0`, so that our VMs use the virtual network bridge `virbr0`. 
+Our script [`prepare_net_cfg.sh`](./prepare_net_cfg.sh) checks the given virtual bridge and adjust the prefix of the IP declared in the network configuration file. Example configuration files are given in the [cloud_configs](./cloud_configs/) folder. They are used mainly to pre-determine the IPs of the VMs in the network.
+
+### Notes
+- After you make sure that networking works fine and you can reach the VM guest from the host, you can log-in the VM using ssh (after placing your ssh keys in the `~/.ssh/autorhized_keys` file of the guest VM) 
+
+### TODO
+- Add authorization keys inside the cloud-config itself

--- a/AMD_SEV_SNP/cloud_configs/cloud-config-client
+++ b/AMD_SEV_SNP/cloud_configs/cloud-config-client
@@ -1,0 +1,9 @@
+#cloud-config
+password: amd_sev
+chpasswd: { expire: False }
+ssh_pwauth: False
+runcmd:
+    - [ sh, -xc, "echo Here is the network config for your instance" ]
+    - [ ip, a ]
+    - [ sh, -xc, "echo 'nameserver 8.8.8.8' >> /etc/resolv.conf" ]
+final_message: "Cloud init is done!"

--- a/AMD_SEV_SNP/cloud_configs/cloud-config-server
+++ b/AMD_SEV_SNP/cloud_configs/cloud-config-server
@@ -1,0 +1,5 @@
+#cloud-config
+password: amd_sev
+chpasswd: { expire: False }
+ssh_pwauth: False
+final_message: "Cloud init is done!"

--- a/AMD_SEV_SNP/cloud_configs/network-config-client.yml
+++ b/AMD_SEV_SNP/cloud_configs/network-config-client.yml
@@ -1,0 +1,13 @@
+version: 1
+config:
+  - type: nameserver
+    address:
+      - 8.8.8.8
+      - 8.8.4.4
+  - type: physical
+    name: enp0s3
+    subnets:
+     - control: auto
+       type: static
+       address: 192.168.122.69/24
+       gateway: 192.168.122.1

--- a/AMD_SEV_SNP/cloud_configs/network-config-server.yml
+++ b/AMD_SEV_SNP/cloud_configs/network-config-server.yml
@@ -1,0 +1,13 @@
+version: 1
+config:
+  - type: nameserver
+    address:
+      - 8.8.8.8
+      - 8.8.4.4
+  - type: physical
+    name: enp0s3
+    subnets:
+     - control: auto
+       type: static
+       address: 192.168.122.48/24
+       gateway: 192.168.122.1

--- a/AMD_SEV_SNP/launch-qemu.sh
+++ b/AMD_SEV_SNP/launch-qemu.sh
@@ -1,0 +1,434 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+#
+# user changeable parameters
+#
+HDA_FILE=""
+HDB_FILE=""
+CPU="EPYC-v4"
+CPU_FEATURES=""
+MEM="4G"
+MAX_MEM=""
+SMP_NCPUS="4"
+MAX_NCPUS=""
+SEV_GUEST=""
+SEV_ES_GUEST=""
+SEV_SNP_GUEST=""
+SVSM=""
+CONSOLE="serial"
+UEFI_BIOS_CODE="./linux-svsm/scripts/usr/local/share/qemu/OVMF_CODE.fd"
+UEFI_BIOS_VARS="./linux-svsm/scripts/usr/local/share/qemu/OVMF_VARS.fd"
+BIOS_DEBUG=""
+VNC_PORT=""
+ALLOW_DEBUG=""
+USE_VIRTIO="1"
+BRIDGE=""
+SEV_POLICY=""
+SNP_FLAGS="0"
+
+QEMU_INSTALL_DIR="./linux-svsm/scripts/usr/local/bin/"
+
+echo $LD_LIBRARY_PATH
+
+usage() {
+	echo "$0 [options]"
+	echo "Available <commands>:"
+	echo " -hda          hard disk ($HDA_FILE)"
+	echo " -hdb          hard disk ($HDB_FILE)"
+	echo " -cpu          CPU model to use ($CPU)"
+	echo " -cpu-features CPU features to add/remove (e.g. '-fsgsbase,+ibpb')"
+	echo " -sev          enable SEV support"
+	echo " -sev-es       enable SEV-ES support"
+	echo " -sev-snp      enable SEV-SNP support"
+	echo " -svsm         SVSM binary (for use with SEV-SNP)"
+	echo " -sev-policy   policy to use for SEV (SEV=0x01, SEV-ES=0x41, SEV-SNP=0x30000)"
+	echo " -snp-flags    SEV-SNP initialization flags (0 is default)"
+	echo " -mem          guest memory (must specify M or G suffix)"
+	echo " -smp          number of cpus"
+	echo " -maxcpus      maximum number of cpus"
+	echo " -console      display console to use (serial or graphics)"
+	echo " -vnc          VNC port to use"
+	echo " -bios         use a specific bios code file (default is ./OVMF_CODE.fd)"
+	echo " -bios-vars    use a specific bios vars file (default is ./OVMF_VARS.fd)"
+	echo " -bios-debug   use the bios debug port (0x402)"
+	echo " -kernel       kernel to use"
+	echo " -initrd       initrd to use"
+	echo " -append       kernel command line arguments to use"
+	echo " -noauto       do not autostart the guest"
+	echo " -cdrom        CDROM image"
+	echo " -allow-debug  allow debugging the VM"
+	echo " -bridge       use the specified bridge device for networking"
+	echo " -novirtio     do not use virtio devices"
+	exit 1
+}
+
+add_opts() {
+	echo -n "$* " >> ${QEMU_CMDLINE}
+}
+
+run_cmd () {
+	$*
+	if [ $? -ne 0 ]; then
+		echo "command $* failed"
+		exit 1
+	fi
+}
+
+stop_network() {
+	if [ "$GUEST_TAP_NAME" = "" ]; then
+		return
+	fi
+	run_cmd "ip tuntap del ${GUEST_TAP_NAME} mode tap"
+}
+
+setup_bridge_network() {
+	# Get last tap device on host
+	TAP_NUM="$(ip link show type tun | grep 'tap[0-9]\+' | sed -re 's|.*tap([0-9]+):.*|\1|' | sort -n | tail -1)"
+	if [ "$TAP_NUM" = "" ]; then
+		TAP_NUM="0"
+	fi
+	TAP_NUM=$((TAP_NUM + 1))
+	GUEST_TAP_NAME="tap${TAP_NUM}"
+
+	[ -n "$USE_VIRTIO" ] && PREFIX="52:54:00" || PREFIX="02:16:1e"
+	SUFFIX="$(ip address show dev $BRIDGE | grep link/ether | awk '{print $2}' | awk -F : '{print $4 ":" $5}')"
+	GUEST_MAC_ADDR=$(printf "%s:%s:%02x" $PREFIX $SUFFIX $TAP_NUM)
+
+	echo "Starting network adapter '${GUEST_TAP_NAME}' MAC=$GUEST_MAC_ADDR"
+	run_cmd "ip tuntap add $GUEST_TAP_NAME mode tap user `whoami`"
+	run_cmd "ip link set $GUEST_TAP_NAME up"
+	run_cmd "ip link set $GUEST_TAP_NAME master $BRIDGE"
+
+	if [ -n "$USE_VIRTIO" ]; then
+		add_opts "-netdev type=tap,script=no,downscript=no,id=net0,ifname=$GUEST_TAP_NAME"
+		add_opts "-device virtio-net-pci,mac=${GUEST_MAC_ADDR},netdev=net0,disable-legacy=on,iommu_platform=true,romfile="
+	else
+		add_opts "-netdev tap,id=net0,ifname=$GUEST_TAP_NAME,script=no,downscript=no"
+		add_opts "-device e1000,mac=${GUEST_MAC_ADDR},netdev=net0,romfile="
+	fi
+}
+
+get_cbitpos() {
+	#
+	# Get C-bit position directly from the hardware
+	#   Reads of /dev/cpu/x/cpuid have to be 16 bytes in size
+	#     and the seek position represents the CPUID function
+	#     to read.
+	#   The skip parameter of DD skips ibs-sized blocks, so
+	#     can't directly go to 0x8000001f function (since it
+	#     is not a multiple of 16). So just start at 0x80000000
+	#     function and read 32 functions to get to 0x8000001f
+	#   To get to EBX, which contains the C-bit position, skip
+	#     the first 4 bytes (EAX) and then convert 4 bytes.
+	#
+
+	cat <<EOF > tmp-cbit.c
+#include <stdio.h>
+int main() {
+	unsigned int eax, ebx, ecx, edx;
+	asm volatile("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "0"(0x8000001f) : "memory");
+	printf("%d\n", ebx & 0x3f);
+}
+EOF
+
+	make tmp-cbit > /dev/null 2>&1
+	CBITPOS=`./tmp-cbit`
+	rm -f tmp-cbit tmp-cbit.c
+}
+
+exit_from_int() {
+	stop_network
+
+	rm -rf ${QEMU_CMDLINE}
+	# restore the mapping
+	stty intr ^c
+	exit 1
+}
+
+trap exit_from_int SIGINT
+
+if [ `id -u` -ne 0 ]; then
+	echo "Must be run as root!"
+	exit 1
+fi
+
+while [ -n "$1" ]; do
+	case "$1" in
+		-sev)		SEV_GUEST="1"
+				;;
+		-sev-es)	SEV_GUEST="1"
+				SEV_ES_GUEST="1"
+				;;
+		-sev-snp)	SEV_GUEST="1"
+				SEV_ES_GUEST="1"
+				SEV_SNP_GUEST="1"
+				;;
+		-svsm)		SVSM="${2}"
+				shift
+				;;
+		-sev-policy)	SEV_POLICY="${2}"
+				shift
+				;;
+		-snp-flags)	SNP_FLAGS="${2}"
+				shift
+				;;
+		-hda) 		HDA_FILE="${2}"
+				shift
+				;;
+		-hdb) 		HDB_FILE="${2}"
+				shift
+				;;
+		-cpu)		CPU="$2"
+				shift
+				;;
+		-cpu-features)	CPU_FEATURES="$2"
+				shift
+				;;
+		-mem)  		MEM=$2
+				shift
+				;;
+		-maxmem)	MAX_MEM=$2
+				shift
+				;;
+		-console)	CONSOLE=$2
+				shift
+				;;
+		-smp)		SMP_NCPUS=$2
+				shift
+				;;
+		-maxcpus)	MAX_NCPUS=$2
+				shift
+				;;
+		-vnc)		VNC_PORT=$2
+				shift
+				if [ "${VNC_PORT}" = "" ]; then
+					usage
+				fi
+				;;
+		-bios)		UEFI_BIOS_CODE="$2"
+				shift
+				;;
+		-bios-vars)	UEFI_BIOS_VARS="$2"
+				shift
+				;;
+		-bios-debug)	BIOS_DEBUG="1"
+				;;
+		-initrd)	INITRD_FILE=$2
+				shift
+				;;
+		-kernel)	KERNEL_FILE=$2
+				shift
+				;;
+		-append)	APPEND_ARGS=$2
+				shift
+				;;
+		-cdrom)		CDROM_FILE=$2
+				shift
+				;;
+		-allow-debug)   ALLOW_DEBUG="1"
+				;;
+		-bridge)	BRIDGE=$2
+				shift
+				;;
+		-novirtio)      USE_VIRTIO=""
+				;;
+		*) 		usage;;
+	esac
+	shift
+done
+
+[ -n "$SVSM" ] && SNP_FLAGS=$((SNP_FLAGS | 0x04))
+
+[ -z "$UEFI_BIOS_CODE" ] && UEFI_BIOS_CODE="./OVMF_CODE.fd"
+TMP="$(readlink -e $UEFI_BIOS_CODE)"
+[ -z "$TMP" ] && {
+	echo "UEFI CODE file [$UEFI_BIOS_CODE] not found"
+	exit 1
+}
+UEFI_BIOS_CODE="$TMP"
+
+[ -z "$UEFI_BIOS_VARS" ] && UEFI_BIOS_VARS="./OVMF_VARS.fd"
+TMP="$(readlink -e $UEFI_BIOS_VARS)"
+[ -z "$TMP" ] && {
+	echo "UEFI VARS file [$UEFI_BIOS_VARS] not found"
+	exit 1
+}
+UEFI_BIOS_VARS="$TMP"
+
+if [ -n "$HDA_FILE" -o -n "$CDROM_FILE" ]; then
+	[ -n "$HDA_FILE" ] && GUEST_NAME=$HDA_FILE || GUEST_NAME=$CDROM_FILE
+	GUEST_NAME="$(basename $GUEST_NAME | sed -re 's|\.[^\.]+$||')"
+else
+	GUEST_NAME="diskless"
+fi
+
+case "$MEM" in
+	*M)	MEM_IN_MB="${MEM%M}"
+		;;
+	*G)	MEM_IN_MB="${MEM%G}"
+		MEM_IN_MB=$((MEM_IN_MB * 1024))
+		;;
+	 *)	echo "Memory must be specified with the 'M' or 'G' suffix"
+		exit 1
+		;;
+esac
+
+# we add all the qemu command line options into a file
+QEMU_CMDLINE=/tmp/cmdline.$$
+rm -rf ${QEMU_CMDLINE}
+
+add_opts "${QEMU_INSTALL_DIR}qemu-system-x86_64 -enable-kvm"
+
+[ -n "$CPU_FEATURES" ] && CPU="${CPU},$CPU_FEATURES"
+CPU="$CPU,host-phys-bits=true"
+add_opts "-cpu $CPU"
+
+# add number of VCPUs
+[ -n "${SMP_NCPUS}" ] && add_opts "-smp ${SMP_NCPUS}${MAX_NCPUS:+,maxcpus=$MAX_NCPUS}"
+
+# define guest memory
+add_opts "-m ${MEM}${MAX_MEM:+,slots=5,maxmem=$MAX_MEM}"
+
+# If this is SEV guest then add the encryption device objects to enable support
+if [ -n "${SEV_GUEST}" ]; then
+	if [ -z "$SEV_POLICY" ]; then
+		if [ -n "${SEV_SNP_GUEST}" ]; then
+			POLICY=$((0x30000))
+			[ -n "${ALLOW_DEBUG}" ] && POLICY=$((POLICY | 0x80000))
+		else
+			POLICY=$((0x01))
+			[ -n "${ALLOW_DEBUG}" ] && POLICY=$((POLICY & ~0x01))
+			[ -n "${SEV_ES_GUEST}" ] && POLICY=$((POLICY | 0x04))
+		fi
+		SEV_POLICY=$(printf "%#x" $POLICY)
+	fi
+
+	get_cbitpos
+	add_opts "-machine type=q35,memory-encryption=sev0,vmport=off${SVSM:+,svsm=$SVSM}"
+
+	SEV_COMMON="id=sev0,policy=${SEV_POLICY},cbitpos=${CBITPOS},reduced-phys-bits=1"
+	if [ -n "$SEV_SNP_GUEST" ]; then
+		SNP_FLAGS=$(printf "%#x" $SNP_FLAGS)
+		add_opts "-object sev-snp-guest,$SEV_COMMON,init-flags=${SNP_FLAGS},host-data=b2l3bmNvd3FuY21wbXA"
+	else
+		add_opts "-object sev-guest,$SEV_COMMON"
+	fi
+else
+	add_opts "-machine type=q35"
+fi
+
+# The OVMF binary, including the non-volatile variable store, appears as a
+# "normal" qemu drive on the host side, and it is exposed to the guest as a
+# persistent flash device.
+[ -e ./${GUEST_NAME}.fd ] || run_cmd "cp ${UEFI_BIOS_VARS} ${GUEST_NAME}.fd"
+UEFI_BIOS_VARS="./${GUEST_NAME}.fd"
+add_opts "-drive if=pflash,format=raw,unit=0,file=${UEFI_BIOS_CODE},readonly=on"
+add_opts "-drive if=pflash,format=raw,unit=1,file=${UEFI_BIOS_VARS}"
+
+[ -n "$BIOS_DEBUG" ] && {
+	add_opts "-chardev file,id=bios,path=./bios.log"
+	add_opts "-device isa-debugcon,iobase=0x402,chardev=bios"
+}
+
+# add CDROM if specified
+[ -n "${CDROM_FILE}" ] && add_opts "-drive file=${CDROM_FILE},media=cdrom,index=0"
+
+get_image_format() {
+	IMAGE_FILE=$1
+	if [ ! -f "${IMAGE_FILE}" ]; then
+		echo "Missing argument or incorrect parameter \"${IMAGE_FILE}\"";
+		exit 1;
+	fi
+
+	if [ -x "$(command -v qemu-img)" ]; then
+		# Use qemu-img from qemu-utils package to determine the image format
+		IMAGE_FORMAT=$(qemu-img	info ${IMAGE_FILE} | grep "file format" | awk '{ print $NF }')
+	else
+		# qemu-img not found. fallback to naive format detection by file extension.
+		case "${IMAGE_FILE}" in
+			*qcow2)		IMAGE_FORMAT="qcow2"
+					;;
+			*)		IMAGE_FORMAT="raw"
+					;;
+		esac
+	fi
+}
+
+# If harddisk file is specified then add the HDD drive
+if [ -n "${HDA_FILE}" ]; then
+
+	get_image_format ${HDA_FILE}
+
+	if [ -n "$USE_VIRTIO" ]; then
+		add_opts "-drive file=${HDA_FILE},if=none,id=disk0,format=${IMAGE_FORMAT}"
+		add_opts "-device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=true"
+		add_opts "-device scsi-hd,drive=disk0"
+	else
+		add_opts "-drive file=${HDA_FILE},format=${IMAGE_FORMAT}"
+	fi
+fi
+
+if [ -n "${HDB_FILE}" ]; then
+
+	get_image_format ${HDB_FILE}
+
+	if [ -n "$USE_VIRTIO" ]; then
+		add_opts "-drive file=${HDB_FILE},if=none,id=disk1,format=${IMAGE_FORMAT}"
+		add_opts "-device virtio-scsi-pci,id=scsi1,disable-legacy=on,iommu_platform=true"
+		add_opts "-device scsi-hd,drive=disk1"
+	else
+		add_opts "-drive file=${HDB_FILE},format=${IMAGE_FORMAT}"
+	fi
+fi
+
+# if console is serial then disable graphical interface
+if [ "${CONSOLE}" = "serial" ]; then
+	add_opts "-nographic"
+fi
+
+# if -kernel arg is specified then use the kernel provided in command line for boot
+if [ -n "${KERNEL_FILE}" ]; then
+	add_opts "-kernel $KERNEL_FILE"
+	if [ -n "${APPEND_ARGS}" ]; then
+		add_opts "-append \"${APPEND_ARGS}\""
+	else
+		add_opts "-append \"console=ttyS0 earlyprintk=serial root=/dev/sda2\""
+	fi
+	[ -n "${INITRD_FILE}" ] && add_opts "-initrd ${INITRD_FILE}"
+fi
+
+# start vnc server
+[ -n "${VNC_PORT}" ] && add_opts "-vnc :${VNC_PORT}" && echo "Starting VNC on port ${VNC_PORT}"
+
+# start monitor on pty and named socket 'monitor'
+add_opts "-monitor pty -monitor unix:monitor,server,nowait"
+
+if [ -n "$BRIDGE" ]; then
+	setup_bridge_network
+else
+	add_opts "-netdev user,id=vmnic -device e1000,netdev=vmnic,romfile="
+fi
+
+# log the console  output in stdout.log
+QEMU_CONSOLE_LOG=`pwd`/stdout.log
+
+# save the command line args into log file
+cat $QEMU_CMDLINE | tee ${QEMU_CONSOLE_LOG}
+echo | tee -a ${QEMU_CONSOLE_LOG}
+
+
+# map CTRL-C to CTRL ]
+echo "Mapping CTRL-C to CTRL-]"
+stty intr ^]
+
+echo "Launching VM ..."
+echo "  $QEMU_CMDLINE"
+sleep 1
+bash ${QEMU_CMDLINE} 2>&1 | tee -a ${QEMU_CONSOLE_LOG}
+
+# restore the mapping
+stty intr ^c
+
+#rm -rf ${QEMU_CMDLINE}
+stop_network

--- a/AMD_SEV_SNP/svsm.patch
+++ b/AMD_SEV_SNP/svsm.patch
@@ -1,0 +1,58 @@
+diff --git a/Makefile b/Makefile
+index 3e46cd2..4caa901 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,7 +2,7 @@
+ 
+ GCC		= gcc
+ 
+-SHELL		:= /bin/bash
++SHELL		:= ${SHELL}
+ 
+ A_FLAGS		:= -D__ASSEMBLY__
+ 
+@@ -57,7 +57,7 @@ prereq: .prereq
+ 
+ .prereq:
+ 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+-	source $(HOME)/.cargo/env
++	#source $(HOME)/.cargo/env
+ 	echo "source $(HOME)/.cargo/env" >> ~/.bashrc
+ 	rustup component add rust-src
+ 	rustup component add llvm-tools-preview
+diff --git a/scripts/common.sh b/scripts/common.sh
+index 3d39ce7..2783d7a 100755
+--- a/scripts/common.sh
++++ b/scripts/common.sh
+@@ -61,7 +61,8 @@ build_kernel()
+ 				run_cmd git checkout current/${BRANCH}
+ 				COMMIT=$(git log --format="%h" -1 HEAD)
+ 
+-				run_cmd "cp /boot/config-$(uname -r) .config"
++				#run_cmd "cp /boot/config-$(uname -r) .config"
++				run_cmd "zcat /proc/config.gz > .config"
+ 				run_cmd ./scripts/config --set-str LOCALVERSION "$VER-$COMMIT"
+ 				run_cmd ./scripts/config --disable LOCALVERSION_AUTO
+ 				run_cmd ./scripts/config --enable  DEBUG_INFO
+diff --git a/scripts/launch-qemu.sh b/scripts/launch-qemu.sh
+index 58e55df..ac30df3 100755
+--- a/scripts/launch-qemu.sh
++++ b/scripts/launch-qemu.sh
+@@ -19,6 +19,8 @@ SVSM=""
+ CONSOLE="serial"
+ UEFI_BIOS_CODE="./usr/local/share/qemu/OVMF_CODE.fd"
+ UEFI_BIOS_VARS="./usr/local/share/qemu/OVMF_VARS.fd"
++#UEFI_BIOS_CODE="/run/libvirt/nix-ovmf/OVMF_CODE.fd"
++#UEFI_BIOS_VARS="/run/libvirt/nix-ovmf/OVMF_VARS.fd"
+ BIOS_DEBUG=""
+ VNC_PORT=""
+ ALLOW_DEBUG=""
+@@ -29,6 +31,8 @@ SNP_FLAGS="0"
+ 
+ QEMU_INSTALL_DIR="./usr/local/bin/"
+ 
++echo $LD_LIBRARY_PATH
++
+ usage() {
+ 	echo "$0 [options]"
+ 	echo "Available <commands>:"

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,10 @@ let
       ps.pexpect
       ps.matplotlib
     ]);
+  libraries = [ pixman zlib ];
 in
 mkShell {
+  buildInputs = libraries;
   nativeBuildInputs = [
     #for the kernel module build
     cpuid
@@ -20,6 +22,17 @@ mkShell {
     autoconf
     automake
 
+    #for sev guest
+    ninja
+    glib
+    nasm
+    acpica-tools
+    flex
+    bison
+    elfutils
+    smatch
+    rpm
+
     #general
     bc
     bashInteractive
@@ -30,7 +43,6 @@ mkShell {
     virt-manager
     vim
     libuuid
-    nasm
     file
     bridge-utils
     cloud-utils
@@ -49,7 +61,6 @@ mkShell {
     lz4
     bzip2
     snappy
-    zlib
     gflags
     boost
 
@@ -66,9 +77,10 @@ mkShell {
     doxygen
     codespell
     abseil-cpp
+  ];
 
-    ];
-  
+  # make install strips valueable libraries from our rpath
+  LD_LIBRARY_PATH = lib.makeLibraryPath libraries;
   shellHook = ''
     export KDIR=${linuxPackages_latest.kernel.dev}/lib/modules/${linuxPackages_latest.kernel.dev.modDirVersion}/build
     export PATH=${pythonEnv}/bin:$PATH


### PR DESCRIPTION
- This PR includes the documentation and the appropriate configuration files required to create a sample setup with a client and a server in distinct AMD SEV SNP VMs.
- VMs are using a virtual bridge (e.g., virbr0) for their networking.
- Each VM gets assigned with a configured IP.

TODOs:

- [ ] Create an image with our GDPRuler compiled and link it to the repo.
- [ ] Add a sample entry in the cloud-configs for the authorized keys, to ease the ssh access in the running VMs.