### PR TITLE
support multiple threads in rocksdb_server

### DIFF
--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -5,6 +5,7 @@
 #include <span>
 
 constexpr int s2ns = 1000000000;
+constexpr int s2ms = 1000;
 constexpr int ns_precision = 9;
 
 /* Parse the value corresponding to given option. Return empty string if not found. */

--- a/controller/source/rocksdb_server/server.cpp
+++ b/controller/source/rocksdb_server/server.cpp
@@ -4,10 +4,17 @@
 #include <vector>
 #include <memory>
 #include <boost/asio.hpp>
+#include <thread>
 
 #include "rocksdb_proxy.hpp"
 
 using boost::asio::ip::tcp;
+
+// io_service is the entry point to use boost's async capabilities. It is an interface to the OS I/O services.
+// It manages the threads and the event loop related to connections and handler callbacks. 
+// See here for more info: https://www.boost.org/doc/libs/1_65_1/doc/html/boost_asio/overview/core/basics.html
+//NOLINTNEXTLINE 
+boost::asio::io_service io_service;
 
 /**
  * session class represents a connection handler for a single client.
@@ -20,22 +27,20 @@ public:
   session(tcp::socket socket, std::shared_ptr<rocksdb_proxy> rocksdb_proxy)
       : m_socket(std::move(socket))
       , m_rocksdb_proxy(std::move(rocksdb_proxy))
+      , m_strand(io_service)
   {
   }
 
   void start() {
-    handle_read();
+    auto self = shared_from_this();
+    m_strand.post([self]() {self->handle_read();});
   }
 
 private:
-  // handle_read() makes use of boost asio and it needs to call itself again to process the next chunk received.
-  // NOLINTBEGIN(misc-no-recursion)
   void handle_read() {
-    auto self(shared_from_this());
-    boost::asio::async_read_until(m_socket, m_buffer, '\n',
-      [this, self](boost::system::error_code error_code, std::size_t length) {
-      if (!error_code) {
-        // put buffered data into string excluding the last new line character
+    while (m_socket.is_open()) {
+      try {
+        auto length = boost::asio::read_until(m_socket, m_buffer, '\n');
         auto buffer_begin = boost::asio::buffers_begin(m_buffer.data());
         std::string raw_query(buffer_begin, buffer_begin + static_cast<int>(length) - 1);
         m_buffer.consume(length);
@@ -43,21 +48,21 @@ private:
         response_message response = m_rocksdb_proxy->execute(query);
         std::string raw_response = response.serialize();
         boost::asio::write(m_socket, boost::asio::buffer(raw_response));
-        handle_read();
+      } catch(const boost::wrapexcept<boost::system::system_error>& e) {
+        if (e.code() == boost::asio::error::eof) {
+          std::cout << "Client is finished with the queries. Closing the session..." << std::endl;
+        } else {
+          std::cout << "Exception thrown in handle_read: " << e.what() << std::endl;
+        }
+        break;
       }
-      else if (error_code == boost::asio::error::eof) {
-        std::cout << "Client is finished with the queries. Closing the session..." << std::endl;
-      }
-      else {
-        std::cout << "Error while reading tcp message: " << error_code << std::endl;
-      }
-    });
+    }
   }
-  // NOLINTEND(misc-no-recursion)
 
   tcp::socket m_socket;
   std::shared_ptr<rocksdb_proxy> m_rocksdb_proxy;
   boost::asio::streambuf m_buffer;
+  boost::asio::io_service::strand m_strand;
 };
 
 /**
@@ -69,12 +74,11 @@ private:
 */
 class rocksdb_server {
 public:
-  rocksdb_server(boost::asio::io_service& io_service,
-                 uint16_t port,
+  rocksdb_server(uint16_t port,
                  const std::string& db_path)
       : m_acceptor(io_service, tcp::endpoint(tcp::v4(), port))
       , m_socket(io_service)
-      , m_rocksdb_proxy(make_shared<rocksdb_proxy>(db_path))
+      , m_rocksdb_proxy(std::make_shared<rocksdb_proxy>(db_path))
   {
     std::cout << "Starting server on port: " << port << std::endl;
     do_accept();
@@ -101,16 +105,23 @@ auto main(int argc, char* argv[]) -> int {
   auto args = std::span(argv, static_cast<size_t>(argc));
 
   try {
-    assert(argc == 3 && "Usage: ./rocksdb_server <port> <db_path>");
+    assert(argc == 4 && "Usage: ./rocksdb_server <port> <db_path> <n_threads>");
 
-    // io_service is the entry point to use boost's async capabilities. It is an interface to the OS I/O services.
-    // It manages the threads and the event loop related to connections and handler callbacks. 
-    // See here for more info: https://www.boost.org/doc/libs/1_65_1/doc/html/boost_asio/overview/core/basics.html 
-    boost::asio::io_service io_service;
-    rocksdb_server rocksdb_server(io_service, static_cast<uint16_t>(std::stoul(args[1])), args[2]);
+    rocksdb_server rocksdb_server(static_cast<uint16_t>(std::stoul(args[1])), args[2]);
 
-    // run() method is used to dequeue the async operation results and call the respective handlers.
-    io_service.run();
+    size_t n_threads = std::stoul(args[3]);
+    std::vector<std::thread> handler_threads(n_threads);
+
+    // start handler threads
+    for (size_t i = 0; i < n_threads; i++) {
+      // run() method is used to dequeue the async operation results and call the respective handlers.
+      handler_threads[i] = std::thread {[&]() {io_service.run();} };
+    }
+
+    // join handler threads
+    for (size_t i = 0; i < n_threads; i++) {
+      handler_threads[i].join();
+    }
   } catch (std::exception& e) {
     std::cerr << "Exception in Rocksdb server: " << e.what() << std::endl;
     return 1;


### PR DESCRIPTION
**Overview**
- Created a thread pool for boost::asio handlers.
- Each session/connection runs on a single thread until it is completed.
- When there are no available threads, the connection is queued by the boost::asio event loop. It is then served when a thread becomes available.

**Testing**
- Tested with test_workloads a-d and f with 32, 64, 128 threads.