### PR TITLE
fix the put operation

### DIFF
--- a/controller/source/query_rewriter.cpp
+++ b/controller/source/query_rewriter.cpp
@@ -7,9 +7,10 @@ query_rewriter::query_rewriter()
 {
 }
 
+/* Constructor for putm query operation rewriter */
 query_rewriter::query_rewriter(const query &query_args, 
                                const default_policy &def_policy,
-                               const std::string &old_value)
+                               const std::string &new_query_value)
     : m_name {"gdpr_controller_query_rewriter"}
 {
   /* create the new value based on the query arguments and the default policy */
@@ -21,13 +22,30 @@ query_rewriter::query_rewriter(const query &query_args,
   int64_t expiration = query_args.expiration().has_value() ? query_args.expiration().value() : def_policy.expiration();
   std::string share = query_args.share().has_value() ? query_args.share().value() : def_policy.share();
   bool monitor = query_args.monitor().has_value() ? query_args.monitor().value() : def_policy.monitor();
-
+  
   std::stringstream prefix;
   prefix << user_key            << "|" << (encryption ? "1" : "0")        << "|"
          << purpose.to_ullong() << "|" << objection.to_ullong()           << "|"
          << origin              << "|" << get_expiration_time(expiration) << "|"
          << share               << "|" << (monitor ? "1" : "0")           << "|";
-  m_new_value = prefix.str() + old_value;
+  m_new_value = prefix.str() + new_query_value;
+}
+
+/* Constructor for put query operation rewriter */
+// To suppress bugprone-easily-swappable-parameters warning from clang-tidy
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+query_rewriter::query_rewriter(const std::string &res, const std::string &new_query_value)
+    : m_name {"gdpr_controller_query_rewriter"}
+{
+  /* create the new value based on the current prefix and the new provided value */
+
+  // Find the position of the last "|" character in the string
+  size_t last_delimiter_pos = res.find_last_of('|');
+
+  // Extract the substring up to the position of the last '|' character
+  std::string metadata = res.substr(0, last_delimiter_pos);
+
+  m_new_value = metadata + "|" + new_query_value;
 }
 
 // query_rewriter::~query_rewriter()

--- a/controller/source/query_rewriter.hpp
+++ b/controller/source/query_rewriter.hpp
@@ -17,7 +17,9 @@ public:
 	query_rewriter();
   explicit query_rewriter(const query &query_args, 
                           const default_policy &def_policy, 
-                          const std::string &old_value);
+                          const std::string &new_query_value);
+  explicit query_rewriter(const std::string &res,
+                          const std::string &new_query_value);
   // ~query_rewriter();
 
 	[[nodiscard]] auto name() const -> std::string;


### PR DESCRIPTION
**Functionality adapted:**
if the value exists and the user complies with the gdpr rules (based on the conditional query args and/or the default policy parameters):

- only the value is updated
- the gdpr metadata remain intact