### PR TITLE
Replace `monitor_is_needed()` function 

### DIFF
--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -52,7 +52,7 @@ auto handle_put(const std::unique_ptr<kv_client> &client,
   if (!res) {
     // If no value is returned, check the respective query args
     // If no query args are specified, enforce the default policy for monitoring
-    auto monitor = gdpr_monitor(filter, query_args, def_policy);
+    auto monitor = gdpr_monitor(query_args, def_policy);
     monitor.monitor_query_attempt();
     // construct the gdpr metadata for the new value
     query_rewriter rewriter(query_args, def_policy, query_args.value());

--- a/controller/source/logging/monitor.hpp
+++ b/controller/source/logging/monitor.hpp
@@ -11,18 +11,49 @@ namespace controller {
 */
 class gdpr_monitor {
 public:
+  /* 
+   * Generic query operation (e.g., get, delete, getm, put (on existing value))
+   * Generic constructor when a value is retrieved
+   * Action: Check the current gdpr metadata
+   */ 
   gdpr_monitor(std::shared_ptr<gdpr_filter> filter, const query& query_args, const default_policy& def_policy): 
-    m_filter{std::move(filter)}, m_query_args{query_args}, m_def_policy(def_policy), m_history_logger{logger::get_instance()} {
+    m_filter{std::move(filter)}, m_query_args{query_args}, m_def_policy{def_policy}, 
+    m_history_logger{logger::get_instance()}, m_monitor_needed{m_filter->check_monitoring()} 
+  {
+  }
+  /* 
+   * PUT query operation 
+   * Monitor constructor when a value is put for the first time in the DB
+   * Action: Check the query args & then the default policy
+   */ 
+  gdpr_monitor(const query& query_args, const default_policy& def_policy): 
+    m_filter{nullptr}, m_query_args{query_args}, m_def_policy{def_policy}, 
+    m_history_logger{logger::get_instance()}
+  {
+    m_monitor_needed = m_query_args.monitor().has_value() ? m_query_args.monitor().value() : m_def_policy.monitor();
   }
 
+  // /* 
+  //  * TODO: PUTM query operation 
+  //  * Monitor constructor when the gdpr metadata of a value is updated 
+  //  * Action: It's current gdpr metadata except from the transition from false to true based on query args
+  //  */ 
+  // gdpr_monitor(std::shared_ptr<gdpr_filter> filter, const query& query_args, const default_policy& def_policy): 
+  //   m_filter{std::move(filter)}, m_query_args{query_args}, 
+  //   m_def_policy{def_policy}, m_history_logger{logger::get_instance()} 
+  // {
+  //   m_monitor_needed = (!filter->check_monitoring() && m_query_args.monitor().has_value_or(false)) ?
+  //                       m_query_args.monitor().value() : filter->check_monitoring();      
+  // }
+
   void monitor_query_attempt() {
-    if (monitor_is_needed()) {
+    if (m_monitor_needed) {
       m_history_logger->log_attempt(m_query_args, m_def_policy);
     }
   }
 
   void monitor_query_result(const bool& result, const std::string& new_val = {}) {
-    if (monitor_is_needed()) {
+    if (m_monitor_needed) {
       m_history_logger->log_result(m_query_args, m_def_policy, result, new_val);
     }
   }
@@ -36,17 +67,7 @@ private:
 
   logger* m_history_logger;
 
-  /*
-   * Criteria for monitoring:
-   * 1. if the retrieved value's metadata (filter) have monitor set to true
-   * 2. if there is no retrieved value & the query arguments have monitor set to true
-   * 3. if there is no retrieved value & no specified query args, use the default policy
-   */
-  auto monitor_is_needed() -> bool {
-    return m_filter->check_monitoring() || 
-           (!m_filter->is_valid() && m_query_args.monitor().value_or(false)) || 
-           (!m_filter->is_valid() && !m_query_args.monitor().has_value() && m_def_policy.monitor());
-  }
+  bool m_monitor_needed;
 
 };
 


### PR DESCRIPTION
The function `monitor_is_needed()` is replaced with a private boolean member variable (`m_monitor_needed`) that is set at the construction time of the monitor object.
Additional sample example for the putm monitor logic is added as a comment in the `monitor.hpp` for ease of future extensibility.