### PR TITLE
Include the `putm` operation monitor constructor logic

### DIFF
--- a/controller/source/logging/monitor.hpp
+++ b/controller/source/logging/monitor.hpp
@@ -11,6 +11,8 @@ namespace controller {
 */
 class gdpr_monitor {
 public:
+  /* Tags for tag dispatching to enable putm behaviour */
+  struct putm_monitor_t {};
   /* 
    * Generic query operation (e.g., get, delete, getm, put (on existing value))
    * Generic constructor when a value is retrieved
@@ -33,18 +35,20 @@ public:
     m_monitor_needed = m_query_args.monitor().has_value() ? m_query_args.monitor().value() : m_def_policy.monitor();
   }
 
-  // /* 
-  //  * TODO: PUTM query operation 
-  //  * Monitor constructor when the gdpr metadata of a value is updated 
-  //  * Action: It's current gdpr metadata except from the transition from false to true based on query args
-  //  */ 
-  // gdpr_monitor(std::shared_ptr<gdpr_filter> filter, const query& query_args, const default_policy& def_policy): 
-  //   m_filter{std::move(filter)}, m_query_args{query_args}, 
-  //   m_def_policy{def_policy}, m_history_logger{logger::get_instance()} 
-  // {
-  //   m_monitor_needed = (!filter->check_monitoring() && m_query_args.monitor().has_value_or(false)) ?
-  //                       m_query_args.monitor().value() : filter->check_monitoring();      
-  // }
+  /* 
+   * PUTM query operation 
+   * Monitor constructor when the gdpr metadata of a value is updated 
+   * Action: It's current gdpr metadata except from the transition from false to true based on query args
+   * callable as: gdpr_monitor(filter, query_args, def_policy, controller::gdpr_monitor::putm_monitor_t{});
+   */ 
+  gdpr_monitor(std::shared_ptr<gdpr_filter> filter, const query& query_args,
+              const default_policy& def_policy, putm_monitor_t /*unused*/): 
+    m_filter{std::move(filter)}, m_query_args{query_args}, 
+    m_def_policy{def_policy}, m_history_logger{logger::get_instance()} 
+  {
+    m_monitor_needed = (!m_filter->check_monitoring() && m_query_args.monitor().value_or(false)) ?
+                        m_query_args.monitor().value() : m_filter->check_monitoring();      
+  }
 
   void monitor_query_attempt() {
     if (m_monitor_needed) {


### PR DESCRIPTION
Description:
make use of tag dispatching to differentiate `putm` monitor constructor logic from the generic monitor constructor logic

For the `putm` operation, the logging is required if:
1. the current gdpr metadata of the value define so
2. there is a gdpr monitor metadata transition from `false` to `true` based on query args