### PR TITLE
Fixing the management of file descriptors (sockets & files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ $ cmake --build build
 
 **Useful options:**
 - Enable/disable the encryption with `-D ENCRYPTION_ENABLED=ON/OFF` (defaults to `ON`)
-- Enable/disable AddressSanitizer with `-D SANITIZER_ENABLED=ON/OFF` (defaults to `OFF`)
+- Enable/disable AddressSanitizer with `-D ASAN_ENABLED=ON/OFF` (defaults to `OFF`)
+- Enable/disable ThreadSanitizer with `-D TSAN_ENABLED=ON/OFF` (defaults to `OFF`)
 
 ### 3. Compile `redis` (to build the `redis-server` binary):
 ```

--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -24,12 +24,20 @@ else()
   message(STATUS "Encryption enabled: OFF")
 endif()
 
-if(SANITIZER_ENABLED)
+if(ASAN_ENABLED)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address  -fsanitize=leak -g")
   message(STATUS "ASan: ON")
 else()
   message(STATUS "ASan: OFF")
 endif()
+
+if(TSAN_ENABLED)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -g")
+  message(STATUS "TSan: ON")
+else()
+  message(STATUS "TSan: OFF")
+endif()
+
 
 # ---- Declare library ----
 

--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <span>
+#include <unistd.h>
 #include <sys/socket.h>
 
 constexpr int s2ns = 1000000000;
@@ -25,6 +26,14 @@ auto inline get_command_line_argument(const auto& args, const std::string& optio
     return args[option_index + 1];
   }
   return {};
+}
+
+// Function to safely close a socket
+auto inline safe_close_socket(int socket) -> void {
+  int result = close(socket);
+  if (result != 0) {
+    std::cerr << "Error closing client socket with fd:" << socket << std::endl;
+  }
 }
 
 // Function to safely receive a specified number of bytes from the socket

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -280,10 +280,7 @@ auto handle_connection
     }
   }
   // Close the client socket
-  int result = close(socket);
-  if (result != 0) {
-    std::cerr << "Error closing client socket" << std::endl;
-  }
+  safe_close_socket(socket);
 }
 
 auto main(int argc, char* argv[]) -> int
@@ -347,14 +344,14 @@ auto main(int argc, char* argv[]) -> int
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   if (bind(listen_socket, reinterpret_cast<struct sockaddr*>(&server_address), sizeof(server_address)) == -1) {
     std::cerr << "Failed to bind socket to address" << std::endl;
-    close(listen_socket);
+    safe_close_socket(listen_socket);
     return 1;
   }
 
   // Start listening for incoming connections
   if (listen(listen_socket, SOMAXCONN) == -1) {
     std::cerr << "Failed to listen for connections" << std::endl;
-    close(listen_socket);
+    safe_close_socket(listen_socket);
     return 1;
   }
 

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -279,6 +279,11 @@ auto handle_connection
       break;
     }
   }
+  // Close the client socket
+  int result = close(socket);
+  if (result != 0) {
+    std::cerr << "Error closing client socket" << std::endl;
+  }
 }
 
 auto main(int argc, char* argv[]) -> int
@@ -366,6 +371,7 @@ auto main(int argc, char* argv[]) -> int
     }
 
     // Create a new thread and pass the client socket to it
+    // The client socket must be independently managed by the thread now
     std::thread connection_thread(handle_connection, client_socket, db_type, db_address, def_policy);
     connection_thread.detach();  // Detach the thread and let it run independently
   }

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -334,6 +334,14 @@ auto main(int argc, char* argv[]) -> int
     return 1;
   }
 
+  // Enable SO_REUSEADDR option
+  int reuse = 1;
+  if (setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) == -1) {
+    std::cerr << "Failed to set SO_REUSEADDR option" << std::endl;
+    safe_close_socket(listen_socket);
+    return 1;
+  }
+
   // Setup the frontend server (controller) socket
   struct sockaddr_in server_address{};
   server_address.sin_family = AF_INET;

--- a/controller/source/kv_client/rocksdb.hpp
+++ b/controller/source/kv_client/rocksdb.hpp
@@ -54,11 +54,11 @@ public:
 
     response_message response = execute(query);
     // std::cout << "PUT operation request Key: " << key << std::endl;
-    if (response.op_is_successful()) {
+    // if (response.op_is_successful()) {
       // std::cout << "PUT operation succeeded! Key: " << key << std::endl;
-    } else {
+    // } else {
       // std::cout << "PUT operation failed" << std::endl;
-    }
+    // }
     return response.op_is_successful();
   }
 
@@ -70,11 +70,11 @@ public:
     query.set_is_valid(/*is_valid*/true);
 
     response_message response = execute(query);
-    if (response.op_is_successful()) {
+    // if (response.op_is_successful()) {
       // std::cout << "DELETE operation succeeded! Key: " << key << std::endl;
-    } else {
+    // } else {
       // std::cout << "DELETE operation failed" << std::endl;
-    }
+    // }
     return response.op_is_successful();
   }
 

--- a/controller/source/logging/log_common.hpp
+++ b/controller/source/logging/log_common.hpp
@@ -163,5 +163,30 @@ inline auto gdpr_metadata_fmt(const std::string &value_str) -> std::string {
 
   return res.str();
 }
+
+/*
+ * Get the maximum number of file descriptors allowed for the current process
+ */
+inline auto get_max_fds() -> size_t {
+  const char* ulimit_command = "ulimit -n";
+  FILE* pipe = popen(ulimit_command, "r");
+  if (!pipe) {
+    std::cerr << "Error executing ulimit command." << std::endl;
+    return 0;
+  }
+
+  size_t buf_size = 128;
+  char buffer[buf_size];
+  std::string result;
+  while (!feof(pipe)) {
+    if (fgets(buffer, buf_size, pipe) != nullptr) {
+      result += buffer;
+    }
+  }
+
+  pclose(pipe);
+
+  return std::stoi(result);
+}
   
 } // namespace controller

--- a/controller/source/native_controller.cpp
+++ b/controller/source/native_controller.cpp
@@ -118,6 +118,11 @@ auto handle_connection(int socket, const std::string& db_type, const std::string
       break;
     }
   }
+  // Close the client socket
+  int result = close(socket);
+  if (result != 0) {
+    std::cerr << "Error closing client socket" << std::endl;
+  }
 }
 
 auto main(int argc, char* argv[]) -> int
@@ -175,6 +180,7 @@ auto main(int argc, char* argv[]) -> int
     }
 
     // Create a new thread and pass the client socket to it
+    // The client socket must be independently managed by the thread now
     std::thread connection_thread(handle_connection, client_socket, db_type, db_address);
     connection_thread.detach();  // Detach the thread and let it run independently
   }

--- a/controller/source/native_controller.cpp
+++ b/controller/source/native_controller.cpp
@@ -146,6 +146,14 @@ auto main(int argc, char* argv[]) -> int
     return 1;
   }
 
+  // Enable SO_REUSEADDR option
+  int reuse = 1;
+  if (setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) == -1) {
+    std::cerr << "Failed to set SO_REUSEADDR option" << std::endl;
+    safe_close_socket(listen_socket);
+    return 1;
+  }
+
   // Setup the frontend server (controller) socket
   struct sockaddr_in server_address{};
   server_address.sin_family = AF_INET;


### PR DESCRIPTION
This PR includes the following:

- [source] Fix leaked socket FD for the client socket:
    - Close the socket connecting the controller with the client(s) when the client sends the exit message
    - Apply the fix in both the native and gdpr controller
- [CMakeLists.txt] add TSan compile option
- [README.md]  adapt ASan compile option & add TSan compile option in the README
- [controller] Implement LRU policy for the file descriptors -- pending: performance testing
