### PR TITLE
Decouple client policy configuration from the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ $ python3 scripts/native_ctl.py --db [redis/rocksdb]
 ```
 For the native GDPR controller:
 ```
-$ python3 scripts/GDPRuler.py --config [user_config] --db [redis/rocksdb]
+$ python3 scripts/GDPRuler.py --db [redis/rocksdb]
 ```
 
 For more command line options, please consult [`scripts/native_ctl.py`](scripts/native_ctl.py) and [`scripts/GDPRuler.py`](scripts/GDPRuler.py).
 
 ### 4. Run the client(s) with a desired workload:
 ```
-$ python3 scripts/client.py --workload [workload_trace_name] --clients [num_of_clients]
+$ python3 scripts/client.py --workload [workload_trace_name] --clients [num_of_clients] --config [user_config/user_config_directory]
 ```
 
 For more command line options, please consult [`scripts/client.py`](scripts/client.py).

--- a/evaluation/DOCUMENTATION.md
+++ b/evaluation/DOCUMENTATION.md
@@ -159,7 +159,7 @@ This Expect script automates the deployment and execution of a controller confid
 - Configuration: Modify the script variables according to your environment and requirements, such as VM settings, database details, controller type, and output file path.
 - Execution: Run the script with appropriate arguments:
 ```
-./script_name <cores> <memory> <db_type> <db_address> <controller_address> <controller_port> <output_file> <gdpr_config> <gdpr_log_path>
+./script_name <cores> <memory> <db_type> <db_address> <controller_address> <controller_port> <output_file> <gdpr_log_path>
 ```
 to deploy the VM and start the controller.
 - Functionality:
@@ -190,7 +190,7 @@ This Expect script automates the deployment and execution of a controller virtua
 - Configuration: Modify the script variables according to your environment and requirements, such as VM settings, database details, controller type, and output file path.
 - Execution: Run the script with appropriate arguments:
 ```
-./script_name <controller_type> <cores> <memory> <db_type> <db_address> <controller_address> <controller_port> <output_file> <gdpr_config> <gdpr_log_path>
+./script_name <controller_type> <cores> <memory> <db_type> <db_address> <controller_address> <controller_port> <output_file> <gdpr_log_path>
 ```
 to deploy the VM and start the controller.
 - Functionality:

--- a/evaluation/VM/CVM_GDPRuler.expect
+++ b/evaluation/VM/CVM_GDPRuler.expect
@@ -18,10 +18,8 @@ set controller_address [lindex $argv 4];
 set controller_port [lindex $argv 5];
 # indicates the output file path
 set output_file [lindex $argv 6];
-# (GDPR only) indicates the gdpr config
-set gdpr_config [lindex $argv 7];
 # (GDPR only) indicates the gdpr log path
-set gdpr_log_path [lindex $argv 8];
+set gdpr_log_path [lindex $argv 7];
 
 # Launch the controller VM
 spawn sudo LD_LIBRARY_PATH=$::env(LD_LIBRARY_PATH) numactl --cpunodebind=0 --membind=0   \
@@ -59,5 +57,5 @@ expect -- "# "
 send -- "mkdir -p $gdpr_log_path\r"
 expect -- "# "
 # Run GDPR controller
-send -- "python3 scripts/GDPRuler.py --db $db_type --config $gdpr_config --logpath $gdpr_log_path --db_address $db_address --controller_address $controller_address --controller_port $controller_port > $output_file\r"
+send -- "python3 scripts/GDPRuler.py --db $db_type --logpath $gdpr_log_path --db_address $db_address --controller_address $controller_address --controller_port $controller_port > $output_file\r"
 expect -- "# "

--- a/evaluation/VM/cloud_hosted_db.sh
+++ b/evaluation/VM/cloud_hosted_db.sh
@@ -44,7 +44,7 @@ for n_clients in $clients; do
   # copy the configs in the controller image
   virt-customize --add ${images_dir}/controller.img --copy-in ${script_dir}/../configs:/root
   # set the client config file appropriately
-  client_cfg=/root/configs/client0_config.json
+  client_cfg=/root/configs/
   for db in $dbs; do
     for workload in $workloads; do
       if [[ $db == "rocksdb" ]]; then

--- a/evaluation/VM/cloud_hosted_db.sh
+++ b/evaluation/VM/cloud_hosted_db.sh
@@ -44,7 +44,7 @@ for n_clients in $clients; do
   # copy the configs in the controller image
   virt-customize --add ${images_dir}/controller.img --copy-in ${script_dir}/../configs:/root
   # set the client config file appropriately
-  client_cfg=/root/configs/
+  client_cfg=$script_dir/../configs/
   for db in $dbs; do
     for workload in $workloads; do
       if [[ $db == "rocksdb" ]]; then

--- a/evaluation/VM/confidential_cloud_hosted_db.sh
+++ b/evaluation/VM/confidential_cloud_hosted_db.sh
@@ -45,7 +45,7 @@ for n_clients in $clients; do
   # copy the configs in the controller image
   virt-customize --add ${images_dir}/controller.img --copy-in ${script_dir}/../configs:/root
   # set the client config file appropriately
-  client_cfg=/root/configs/client0_config.json
+  client_cfg=/root/configs/
   for db in $dbs; do
     for workload in $workloads; do
       if [[ $db == "rocksdb" ]]; then

--- a/evaluation/VM/confidential_cloud_hosted_db.sh
+++ b/evaluation/VM/confidential_cloud_hosted_db.sh
@@ -45,7 +45,7 @@ for n_clients in $clients; do
   # copy the configs in the controller image
   virt-customize --add ${images_dir}/controller.img --copy-in ${script_dir}/../configs:/root
   # set the client config file appropriately
-  client_cfg=/root/configs/
+  client_cfg=$script_dir/../configs/
   for db in $dbs; do
     for workload in $workloads; do
       if [[ $db == "rocksdb" ]]; then

--- a/evaluation/VM/self_hosted_db.sh
+++ b/evaluation/VM/self_hosted_db.sh
@@ -44,7 +44,7 @@ for n_clients in $clients; do
   # copy the configs in the controller image
   virt-customize --add ${images_dir}/controller.img --copy-in ${script_dir}/../configs:/root
   # set the client config file appropriately
-  client_cfg=/root/configs/client0_config.json
+  client_cfg=/root/configs/
   for db in $dbs; do
     for workload in $workloads; do
       if [[ $db == "rocksdb" ]]; then

--- a/evaluation/VM/self_hosted_db.sh
+++ b/evaluation/VM/self_hosted_db.sh
@@ -44,7 +44,7 @@ for n_clients in $clients; do
   # copy the configs in the controller image
   virt-customize --add ${images_dir}/controller.img --copy-in ${script_dir}/../configs:/root
   # set the client config file appropriately
-  client_cfg=/root/configs/
+  client_cfg=$script_dir/../configs/
   for db in $dbs; do
     for workload in $workloads; do
       if [[ $db == "rocksdb" ]]; then

--- a/evaluation/bare_metal/gdpr_ctl.sh
+++ b/evaluation/bare_metal/gdpr_ctl.sh
@@ -38,7 +38,7 @@ for n_clients in $clients; do
   # prepare the client configs
   prepare_configs $n_clients
   # set the client config file appropriately
-  client_cfg=$script_dir/../configs/client0_config.json
+  client_cfg=$script_dir/../configs/
   for db in $dbs; do
     for workload in $workloads; do
       if [[ $db == "rocksdb" ]]; then

--- a/evaluation/bare_metal/native_ctl.sh
+++ b/evaluation/bare_metal/native_ctl.sh
@@ -27,7 +27,7 @@ for n_clients in $clients; do
       fi
       echo "Starting a run with $n_clients clients, $db store, $controller controller, and $workload."
       run_native_ctl_experiment $n_clients $workload $db $db_address $db_port \
-      $controller $controller_address $controller_port "" $results_csv_file
+      $controller $controller_address $controller_port "no_cfg" $results_csv_file
       echo ""
     done
   done

--- a/evaluation/default_policy_creator.sh
+++ b/evaluation/default_policy_creator.sh
@@ -108,7 +108,7 @@ $purpose    ],
     "objection": [
 $objection    ],
     "origin": [
-      "src0"
+      "src${user_id}"
     ],
     "expTime": [
       "0"

--- a/scripts/GDPRuler.py
+++ b/scripts/GDPRuler.py
@@ -7,9 +7,7 @@ from common import DbType
 
 curr_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(curr_dir)
-sys.path.insert(0, parent_dir) 
-from policy_compiler.helper import safe_open
-from policy_compiler.policy_config import parse_user_policy
+sys.path.insert(0, parent_dir)
 
 # Define a custom validation function for the --db_encryptionkey argument
 def validate_encryption_key(key):
@@ -21,7 +19,6 @@ def main():
   default_db_encryption_key = "0123456789abcdef"
   default_log_encryption_key = "abcdef0123456789"
   parser = argparse.ArgumentParser(description='Start GDPRuler instance.')
-  parser.add_argument('--config', help='path to the default config trace file', default=None, required=True, type=str)
   parser.add_argument('--db', help='db to use, one of {rocksdb,redis}', default=DbType.ROCKSDB, required=False, type=DbType)
   parser.add_argument('--db_address', help='db ip address for client to connect', default=None, required=False, type=str)
   parser.add_argument('--logpath', help='folder to place the gdpr log files', default="./logs", required=False, type=str)
@@ -32,12 +29,6 @@ def main():
   parser.add_argument('--controller_address', help='controller IP address', default="127.0.0.1", required=False, type=str)
   parser.add_argument('--controller_port', help='controller port', default="1312", required=False, type=str)
   args = parser.parse_args()
-
-  user_policy = safe_open(args.config, "r") # open the file containing the default user configuration
-  user_policy = json.load(user_policy)
-
-  # Set up the default policy in the gdpr controller
-  def_policy = parse_user_policy(user_policy)
 
   # Open the controller process
   process_args = [os.path.join(os.path.dirname(os.path.abspath(__file__)), '../controller/build/gdpr_controller')]
@@ -52,10 +43,6 @@ def main():
   process_args += ['--controller_address', args.controller_address]
   process_args += ['--controller_port', args.controller_port]
   controller = subprocess.Popen(process_args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-
-  # Write policy to process' standard input
-  controller.stdin.write(def_policy.encode() + b'\n')
-  controller.stdin.flush()
 
   # Wait for the controller process to exit
   controller.wait()

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -62,13 +62,14 @@ def load_workload(server_address, server_port, workload_name, value_size, config
 
   value = generate_value(value_size)
 
-  # Load and send default policy - get the client 0 as default policy 
-  default_policy = load_config(config_path, 0)
-  if not send_default_policy(client_socket, default_policy):
-    print(f"Failed to set default policy for the workload loader")
-    client_socket.close()
-    return
-    
+  # Load and send default policy - get the client 0 as default policy
+  if config_path != "no_cfg":
+    default_policy = load_config(config_path, 0)
+    if not send_default_policy(client_socket, default_policy):
+      print(f"Failed to set default policy for the workload loader")
+      client_socket.close()
+      return
+
   with safe_open(load_file, 'r') as file:
     for line in file:
       if not line.startswith("#"):
@@ -110,12 +111,13 @@ def send_queries(server_address, server_port, queries, latency_results, config_p
     client_socket.connect((server_address, server_port))
 
     # Load and send default policy
-    default_policy = load_config(config_path, client_num)
-    if not send_default_policy(client_socket, default_policy):
-      print(f"Failed to set default policy for client {client_num}")
-      client_socket.close()
-      return
-    
+    if config_path != "no_cfg":
+      default_policy = load_config(config_path, client_num)
+      if not send_default_policy(client_socket, default_policy):
+        print(f"Failed to set default policy for client {client_num}")
+        client_socket.close()
+        return
+
     # Read the contents of the workload file line by line
     total_latency = 0
     request_count = 0
@@ -158,7 +160,7 @@ def create_client_process(server_address, server_port, queries, latency_results,
 
 def main():
   parser = argparse.ArgumentParser(description='Start a client.')
-  parser.add_argument('--config', help='Path to config file or directory containing client configs', required=True, type=str)
+  parser.add_argument('--config', help='Path to config file or directory containing client configs for the GDPR case. Leave empty for passthrough case', required=True, type=str)
   parser.add_argument('--workload', help='Name of the workload trace', required=True, type=str, choices=get_workload_options())
   parser.add_argument('--address', help='IP address of the server to connect', default="127.0.0.1", required=False, type=str)
   parser.add_argument('--port', help='Port of the running server to connect', default=1312, required=False, type=int)


### PR DESCRIPTION
This PR includes the following:
- update the controller and the scripts so that the default config is now handled **per-client** 
- the `gdpr controller` stores each client's config in a thread local object 
- scripts parameters are adjusted so that the config is passed to the `client.py` and requires either a file for the default config or a directory containing the configs of all the clients with a certain naming convention (`client{client_num}_config.json`)
- update the evaluation automation to use the new config arguments in the client (`no_cfg` for the passthrough case) and adjust the arguments accordingly for both the bare-metal and the VM
- update the documentation