### PR TITLE
Reasoning for performance drop in `direct_client` vs `proxy`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "CVM_setup/AMDSEV"]
 	path = CVM_setup/AMDSEV
 	url = https://github.com/dimstav23/AMDSEV.git
+[submodule "evaluation/microbenchmarks/ipc-bench"]
+	path = evaluation/microbenchmarks/ipc-bench
+	url = git@github.com:dimstav23/ipc-bench.git

--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -77,7 +77,7 @@ auto inline safe_sock_send(int socket, void* buffer, size_t size) -> ssize_t {
 
 // Function to safely receive a specified number of bytes from the socket
 // Optimized version using recvmsg() with iovec and MSG_WAITALL
-auto inline safe_sock_receive(int socket, void* buffer, size_t size) -> ssize_t {
+auto inline safe_sock_receive(int socket, void* buffer) -> ssize_t {
   struct iovec iov;
   struct msghdr msg = {};
 

--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -5,12 +5,16 @@
 #include <span>
 #include <unistd.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
 constexpr int s2ns = 1000000000;
 constexpr int s2ms = 1000;
 constexpr int ns_precision = 9;
 
-constexpr int max_msg_size = 8192;
+constexpr int max_msg_size = 4096;
+constexpr size_t msg_header_size = sizeof(uint32_t);
 
 // controller response codes
 constexpr std::string GET_FAILED       = "0";
@@ -49,38 +53,53 @@ auto inline safe_close_socket(int socket) -> void {
   }
 }
 
-// Function to safely receive a specified number of bytes from the socket
-auto inline safe_sock_receive(int socket, void* buffer, size_t size) -> ssize_t {
-  char* ptr = static_cast<char*>(buffer);
-  size_t total_bytes_received = 0;
+// Function to safely send a specified number of bytes to the socket
+// Optimized version using sendmsg() with iovec and MSG_NOSIGNAL
+auto inline safe_sock_send(int socket, void* buffer, size_t size) -> ssize_t {
+  struct iovec iov[2];
+  struct msghdr msg = {};
 
-  while (total_bytes_received < size) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    ssize_t bytes_received = recv(socket, ptr + total_bytes_received, size - total_bytes_received, 0);
-    if (bytes_received <= 0) {
-      // Failed to receive bytes or connection closed
-      return bytes_received;
-    }
-    total_bytes_received += static_cast<size_t>(bytes_received);
-  }
+  uint32_t msg_size = htonl(size);
 
-  return static_cast<ssize_t>(total_bytes_received);
+  // Set up iov for the message header with the size
+  iov[0].iov_base = &msg_size;
+  iov[0].iov_len = msg_header_size;
+
+  // Set up iov for the actual message
+  iov[1].iov_base = buffer;
+  iov[1].iov_len = size;
+
+  msg.msg_iov = iov;
+  msg.msg_iovlen = 2;
+
+  return sendmsg(socket, &msg, MSG_NOSIGNAL);
 }
 
-// Function to safely send a specified number of bytes to the socket
-auto inline safe_sock_send(int socket, const void* buffer, size_t size) -> ssize_t {
-  const char* ptr = static_cast<const char*>(buffer);
-  size_t total_bytes_sent = 0;
+// Function to safely receive a specified number of bytes from the socket
+// Optimized version using recvmsg() with iovec and MSG_WAITALL
+auto inline safe_sock_receive(int socket, void* buffer, size_t size) -> ssize_t {
+  struct iovec iov;
+  struct msghdr msg = {};
 
-  while (total_bytes_sent < size) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    ssize_t bytes_sent = send(socket, ptr + total_bytes_sent, size - total_bytes_sent, 0);
-    if (bytes_sent <= 0) {
-      // Failed to send bytes or connection closed
-      return bytes_sent;
-    }
-    total_bytes_sent += static_cast<size_t>(bytes_sent);
+  uint32_t msg_size;
+
+  ssize_t bytes_received = recv(socket, &msg_size, sizeof(msg_size), MSG_WAITALL);
+  if (bytes_received < 0) {
+    std::cerr << "Failed to read the message size or the connection is closed." << std::endl;
+    return bytes_received;
   }
 
-  return static_cast<ssize_t>(total_bytes_sent);
+  msg_size = ntohl(msg_size);
+
+  if (msg_size > max_msg_size) {
+    std::cerr << "Incoming message too large!" << std::endl;
+    return -1;
+  }
+
+  iov.iov_base = buffer;
+  iov.iov_len = msg_size;
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+
+  return recvmsg(socket, &msg, MSG_WAITALL);
 }

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -39,7 +39,7 @@ auto receive_policy(int socket) -> std::optional<default_policy>
   }
 
   // Read the policy from the socket
-  ssize_t bytes_read = safe_sock_receive(socket, buffer, max_msg_size);
+  ssize_t bytes_read = safe_sock_receive(socket, buffer);
   if (bytes_read <= 0) {
     std::cerr << "Failed to read the message or the connection is closed." << std::endl;
     return std::nullopt;
@@ -286,7 +286,7 @@ auto handle_connection
 
   while (true) {
     // Read the message size from the socket
-    ssize_t bytes_read = safe_sock_receive(socket, buffer, max_msg_size);
+    ssize_t bytes_read = safe_sock_receive(socket, buffer);
     if (bytes_read <= 0) {
       std::cerr << "Failed to read the message or the connection is closed." << std::endl;
       break;

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -3,11 +3,9 @@
 #include "absl/strings/match.h" // for StartsWith function
 #include <chrono>
 #include <thread>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 #include <cassert>
 #include <functional>
+#include <sys/mman.h>
 
 #include "default_policy.hpp"
 #include "query.hpp"
@@ -33,38 +31,33 @@ thread_local default_policy def_policy;
 
 auto receive_policy(int socket) -> std::optional<default_policy>
 {
-  constexpr size_t header_size = sizeof(uint32_t);
-  std::vector<char> buffer(max_msg_size);
-
-  // Read the policy size from the socket
-  ssize_t bytes_read = safe_sock_receive(socket, buffer.data(), header_size);
-  if (bytes_read != header_size) {
-    std::cerr << "Failed to read the policy size or the connection is closed." << std::endl;
+  // Allocate a large buffer using mmap to hold the message and its size
+  void* buffer = mmap(nullptr, max_msg_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (buffer == MAP_FAILED) {
+    std::cerr << "Failed to allocate buffer" << std::endl;
     return std::nullopt;
   }
 
-  uint32_t policy_size = 0;
-  std::memcpy(&policy_size, buffer.data(), sizeof(uint32_t));
-  policy_size = ntohl(policy_size);
-
-  if (policy_size > buffer.size() - 1) {
-    buffer.resize(policy_size + 1);
-  }
-
-  bytes_read = safe_sock_receive(socket, buffer.data(), policy_size);
-  if (bytes_read != static_cast<ssize_t>(policy_size)) {
-    std::cerr << "Failed to read the policy or the connection is closed." << std::endl;
+  // Read the policy from the socket
+  ssize_t bytes_read = safe_sock_receive(socket, buffer, max_msg_size);
+  if (bytes_read <= 0) {
+    std::cerr << "Failed to read the message or the connection is closed." << std::endl;
     return std::nullopt;
   }
+  // Set the termination character for the string
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  (static_cast<char*>(buffer))[bytes_read] = '\0';
 
-  std::string client_policy(buffer.data());
+  std::string client_policy(static_cast<char*>(buffer));
 
   // Send acknowledgment for policy receive
   std::string ack = "ACK\0";
-  uint32_t ack_size = htonl(static_cast<uint32_t>(ack.length()));
-  std::memcpy(buffer.data(), &ack_size, sizeof(uint32_t));
-  std::memcpy(buffer.data() + sizeof(uint32_t), ack.c_str(), ack.length());
-  safe_sock_send(socket, buffer.data(), sizeof(uint32_t) + ack.length());
+  // Send the response to the client
+  ssize_t bytes_sent = safe_sock_send(socket, ack.data(), ack.length());
+  if (bytes_sent <= 0) {
+    std::cerr << "Failed to send the response to the client or the connection is closed." << std::endl;
+    return std::nullopt;
+  }
 
   return default_policy(client_policy);
 }
@@ -284,41 +277,27 @@ auto handle_connection
   // Create the connection with the database instance
   std::unique_ptr<kv_client> client = kv_factory::create(db_type, db_address);
 
-  constexpr size_t header_size = sizeof(uint32_t);  // Size of the header containing the message size
-  std::vector<char> buffer(max_msg_size);  // Buffer to hold the message and its size
+  // Allocate a large buffer using mmap to hold the message and its size
+  void* buffer = mmap(nullptr, max_msg_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (buffer == MAP_FAILED) {
+    std::cerr << "Failed to allocate buffer" << std::endl;
+    return;
+  }
 
   while (true) {
     // Read the message size from the socket
-    ssize_t bytes_read = safe_sock_receive(socket, buffer.data(), header_size);
-    if (bytes_read != header_size) {
-      std::cerr << "Failed to read the message size or the connection is closed." << std::endl;
-      break;
-    }
-    
-    // Convert network byte order to host byte order
-    uint32_t msg_size = 0;
-    std::memcpy(&msg_size, buffer.data(), sizeof(uint32_t));
-    msg_size = ntohl(msg_size);
-
-    // Resize the buffer if needed (+-1 for the null termination character)
-    if (msg_size + header_size > buffer.size() - 1) {
-      buffer.resize(msg_size + header_size + 1);
-    }
-
-    // Read the message data from the socket
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    bytes_read = safe_sock_receive(socket, buffer.data() + header_size, msg_size);
-    if (bytes_read != static_cast<ssize_t>(msg_size)) {
+    ssize_t bytes_read = safe_sock_receive(socket, buffer, max_msg_size);
+    if (bytes_read <= 0) {
       std::cerr << "Failed to read the message or the connection is closed." << std::endl;
       break;
     }
-
+    
     // Set the termination character for the string
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    buffer[static_cast<size_t>(bytes_read) + header_size] = '\0';
+    (static_cast<char*>(buffer))[bytes_read] = '\0';
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    const query query_args(buffer.data() + header_size);
+    query query_args(static_cast<char*>(buffer));
     std::string response;
 
     if (query_args.cmd() == "exit") [[unlikely]] {
@@ -326,7 +305,6 @@ auto handle_connection
       break;
     }
     else if (query_args.cmd() == "invalid") [[unlikely]] {
-      // std::cout << "Invalid command" << std::endl;
       response = INVALID_COMMAND;
     }
     else [[likely]] {
@@ -350,34 +328,26 @@ auto handle_connection
         response = handle_get_logs(query_args, def_policy);
       }
       else {
-        // std::cout << "Invalid command: " << query_args.cmd() << std::endl;
         response = INVALID_COMMAND;
       }
     }
 
-    // Resize the buffer (if needed) to accommodate the response
+    // Check the message size
     size_t response_length = response.length();
-    if (header_size + response_length > buffer.size()) {
-      buffer.resize(header_size + response_length);
+    if (response_length > max_msg_size) {
+      std::cerr << "Outgoing message too large." << std::endl;
+      break;
     }
 
-    // Prepare the response size header
-    auto response_size = static_cast<uint32_t>(response_length);
-    response_size = htonl(response_size);
-    std::memcpy(buffer.data(), &response_size, header_size);
-
-    // Copy the response data to the buffer
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    std::memcpy(buffer.data() + header_size, response.c_str(), response_length);
-
     // Send the response to the client
-    ssize_t bytes_sent = safe_sock_send(socket, buffer.data(), header_size + response_length);
+    ssize_t bytes_sent = safe_sock_send(socket, response.data(), response_length);
     if (bytes_sent <= 0) {
-      // Failed to send the response or connection closed
       std::cerr << "Failed to send the response to the client or the connection is closed." << std::endl;
       break;
     }
   }
+  // Unmap the socket communication buffer
+  munmap(buffer, max_msg_size);
   // Close the client socket
   safe_close_socket(socket);
 }
@@ -425,6 +395,13 @@ auto main(int argc, char* argv[]) -> int
   int reuse = 1;
   if (setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) == -1) {
     std::cerr << "Failed to set SO_REUSEADDR option" << std::endl;
+    safe_close_socket(listen_socket);
+    return 1;
+  }
+
+  int tcpnodelay = 1;
+  if (setsockopt(listen_socket, IPPROTO_TCP, TCP_NODELAY, &tcpnodelay, sizeof(tcpnodelay))) {
+    std::cerr << "Failed to set TCP_NODELAY option" << std::endl;
     safe_close_socket(listen_socket);
     return 1;
   }

--- a/controller/source/kv_client/kv_client.hpp
+++ b/controller/source/kv_client/kv_client.hpp
@@ -13,7 +13,7 @@ public:
   inline auto gdpr_get(std::string_view key) -> std::optional<std::string> {
     #ifndef ENCRYPTION_ENABLED
       // get the value directly w/o decryption
-      return get(key);
+      return std::move(get(key));
     #else
       // get the value after decryption
       auto encrypted_value = get(key);

--- a/controller/source/kv_client/kv_client.hpp
+++ b/controller/source/kv_client/kv_client.hpp
@@ -10,7 +10,7 @@ class kv_client
 {
 public:
   /* kv_client interface signatures */
-  auto gdpr_get(std::string_view key) -> std::optional<std::string> {
+  inline auto gdpr_get(std::string_view key) -> std::optional<std::string> {
     #ifndef ENCRYPTION_ENABLED
       // get the value directly w/o decryption
       return get(key);
@@ -31,7 +31,7 @@ public:
   }
 
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  auto gdpr_put(std::string_view key, std::string_view value) -> bool {
+  inline auto gdpr_put(std::string_view key, std::string_view value) -> bool {
     #ifndef ENCRYPTION_ENABLED
       // put the pair directly w/o encryption
       return put(key, value);
@@ -46,7 +46,7 @@ public:
     #endif
   }
 
-  auto gdpr_del(std::string_view key) -> bool {
+  inline auto gdpr_del(std::string_view key) -> bool {
     #ifndef ENCRYPTION_ENABLED
       // delete the pair directly w/o decryption
       return del(key);

--- a/controller/source/kv_client/redis.hpp
+++ b/controller/source/kv_client/redis.hpp
@@ -14,7 +14,7 @@ public:
   {
   }
 
-  auto get(std::string_view key) -> std::optional<std::string> override
+  inline auto get(std::string_view key) -> std::optional<std::string> override
   {
     auto result = m_redis.get(key);
     // if (result) {
@@ -31,7 +31,7 @@ public:
     return result;
   }
 
-  auto put(std::string_view key, std::string_view value) -> bool override
+  inline auto put(std::string_view key, std::string_view value) -> bool override
   {
     bool res = true;
     auto result = m_redis.set(key, value);
@@ -45,7 +45,7 @@ public:
     return res;
   }
 
-  auto del(std::string_view key) -> bool override
+  inline auto del(std::string_view key) -> bool override
   {
     bool res = true;
     auto result = m_redis.del(key);

--- a/controller/source/kv_client/redis.hpp
+++ b/controller/source/kv_client/redis.hpp
@@ -28,7 +28,7 @@ public:
     //   // It's invalid to dereference a null Optional<T> object.
     //   // std::cout << "GET operation failed" << std::endl;
     // }
-    return result;
+    return std::move(result);
   }
 
   inline auto put(std::string_view key, std::string_view value) -> bool override

--- a/controller/source/native_controller.cpp
+++ b/controller/source/native_controller.cpp
@@ -2,9 +2,7 @@
 #include <string>
 #include <chrono>
 #include <thread>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
+#include <sys/mman.h>
 
 #include "kv_client/factory.hpp"
 #include "query.hpp"
@@ -13,27 +11,31 @@
 
 using controller::query;
 
-auto handle_get(const query &query_args, std::unique_ptr<kv_client> &client) -> std::string
+inline auto handle_get(const query &query_args, std::unique_ptr<kv_client> &client) -> std::string
 {
-  auto ret_val = client->gdpr_get(query_args.key());
+  std::string_view key = query_args.key();
+  auto ret_val = client->gdpr_get(key);
   if (ret_val) {
-    return ret_val.value();
+    return std::move(ret_val.value());
   } 
   return GET_FAILED; // GET_FAILED: Non existing key
 }
 
-auto handle_put(const query &query_args, std::unique_ptr<kv_client> &client) -> std::string
+inline auto handle_put(const query &query_args, std::unique_ptr<kv_client> &client) -> std::string
 {
-  bool success = client->gdpr_put(query_args.key(), query_args.value());
+  std::string_view key = query_args.key();
+  std::string_view value = query_args.value();
+  bool success = client->gdpr_put(key, value);
   if (success) {
     return PUT_SUCCESS;
   } 
   return PUT_FAILED; // PUT_FAILED: Failed to put value
 }
 
-auto handle_delete(const query &query_args, std::unique_ptr<kv_client> &client) -> std::string
+inline auto handle_delete(const query &query_args, std::unique_ptr<kv_client> &client) -> std::string
 {
-  bool success = client->gdpr_del(query_args.key());
+  std::string_view key = query_args.key();
+  bool success = client->gdpr_del(key);
   if (success) {
     return DELETE_SUCCESS;
   }
@@ -42,44 +44,30 @@ auto handle_delete(const query &query_args, std::unique_ptr<kv_client> &client) 
 
 auto handle_connection(int socket, const std::string& db_type, const std::string& db_address) -> void
 {
-  constexpr size_t header_size = sizeof(uint32_t);  // Size of the header containing the message size
-  std::vector<char> buffer(max_msg_size);  // Buffer to hold the message and its size
+  // Allocate a large buffer using mmap to hold the message and its size
+  void* buffer = mmap(nullptr, max_msg_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (buffer == MAP_FAILED) {
+    std::cerr << "Failed to allocate buffer" << std::endl;
+    return;
+  }
 
   // create the connection with the database instance
   std::unique_ptr<kv_client> client = kv_factory::create(db_type, db_address);
 
   while (true) {
     // Read the message size from the socket
-    ssize_t bytes_read = safe_sock_receive(socket, buffer.data(), header_size);
-    if (bytes_read != header_size) {
-      std::cerr << "Failed to read the message size or the connection is closed." << std::endl;
-      break;
-    }
-
-    // Convert network byte order to host byte order
-    uint32_t msg_size = 0;
-    std::memcpy(&msg_size, buffer.data(), sizeof(uint32_t));
-    msg_size = ntohl(msg_size);
-
-    // Resize the buffer if needed (+-1 for the null termination character)
-    if (msg_size + header_size > buffer.size() - 1) {
-      buffer.resize(msg_size + header_size + 1);
-    }
-
-    // Read the message data from the socket
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    bytes_read = safe_sock_receive(socket, buffer.data() + header_size, msg_size);
-    if (bytes_read != static_cast<ssize_t>(msg_size)) {
+    ssize_t bytes_read = safe_sock_receive(socket, buffer, max_msg_size);
+    if (bytes_read <= 0) {
       std::cerr << "Failed to read the message or the connection is closed." << std::endl;
       break;
     }
 
     // Set the termination character for the string
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    buffer[static_cast<size_t>(bytes_read) + header_size] = '\0';
+    (static_cast<char*>(buffer))[bytes_read] = '\0';
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    const query query_args(buffer.data() + header_size);
+    query query_args(static_cast<char*>(buffer));
     std::string response;
 
     if (query_args.cmd() == "exit") [[unlikely]] {
@@ -87,7 +75,6 @@ auto handle_connection(int socket, const std::string& db_type, const std::string
       break;
     }
     else if (query_args.cmd() == "invalid") [[unlikely]] {
-      // std::cout << "Invalid command" << std::endl;
       response = INVALID_COMMAND;
     }
     else [[likely]] {
@@ -101,34 +88,27 @@ auto handle_connection(int socket, const std::string& db_type, const std::string
         response = handle_delete(query_args, client);
       }
       else {
-        // std::cout << "Invalid command: " << query_args.cmd() << std::endl;
         response = INVALID_COMMAND;
       }
     }
 
-    // Resize the buffer (if needed) to accommodate the response
+    // Check the message size
     size_t response_length = response.length();
-    if (header_size + response_length > buffer.size()) {
-      buffer.resize(header_size + response_length);
+    if (response_length > max_msg_size) {
+      std::cerr << "Outgoing message too large." << std::endl;
+      break;
     }
 
-    // Prepare the response size header
-    auto response_size = static_cast<uint32_t>(response_length);
-    response_size = htonl(response_size);
-    std::memcpy(buffer.data(), &response_size, header_size);
-
-    // Copy the response data to the buffer
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    std::memcpy(buffer.data() + header_size, response.c_str(), response_length);
-
     // Send the response to the client
-    ssize_t bytes_sent = safe_sock_send(socket, buffer.data(), header_size + response_length);
+    ssize_t bytes_sent = safe_sock_send(socket, response.data(), response_length);
     if (bytes_sent <= 0) {
-      // Failed to send the response or connection closed
       std::cerr << "Failed to send the response to the client or the connection is closed." << std::endl;
       break;
     }
   }
+
+  // Unmap the socket communication buffer
+  munmap(buffer, max_msg_size);
   // Close the client socket
   safe_close_socket(socket);
 }
@@ -158,6 +138,13 @@ auto main(int argc, char* argv[]) -> int
   int reuse = 1;
   if (setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) == -1) {
     std::cerr << "Failed to set SO_REUSEADDR option" << std::endl;
+    safe_close_socket(listen_socket);
+    return 1;
+  }
+  
+  int tcpnodelay = 1;
+  if (setsockopt(listen_socket, IPPROTO_TCP, TCP_NODELAY, &tcpnodelay, sizeof(tcpnodelay))) {
+    std::cerr << "Failed to set TCP_NODELAY option" << std::endl;
     safe_close_socket(listen_socket);
     return 1;
   }

--- a/controller/source/native_controller.cpp
+++ b/controller/source/native_controller.cpp
@@ -56,7 +56,7 @@ auto handle_connection(int socket, const std::string& db_type, const std::string
 
   while (true) {
     // Read the message size from the socket
-    ssize_t bytes_read = safe_sock_receive(socket, buffer, max_msg_size);
+    ssize_t bytes_read = safe_sock_receive(socket, buffer);
     if (bytes_read <= 0) {
       std::cerr << "Failed to read the message or the connection is closed." << std::endl;
       break;

--- a/evaluation/microbenchmarks/cpp_test/.gitignore
+++ b/evaluation/microbenchmarks/cpp_test/.gitignore
@@ -1,0 +1,6 @@
+direct_server
+direct_client
+direct_setup
+proxy_server
+proxy_client
+proxy_setup

--- a/evaluation/microbenchmarks/cpp_test/Makefile
+++ b/evaluation/microbenchmarks/cpp_test/Makefile
@@ -1,0 +1,30 @@
+CC = g++
+CFLAGS = -Wall -O2
+
+all: direct_server direct_client direct_setup proxy_server proxy_client proxy_setup
+
+direct_server: direct_server.cpp
+	$(CC) $(CFLAGS) -o direct_server direct_server.cpp
+
+direct_client: direct_client.cpp
+	$(CC) $(CFLAGS) -o direct_client direct_client.cpp
+
+direct_setup: direct_setup.cpp
+	$(CC) $(CFLAGS) -o direct_setup direct_setup.cpp
+
+proxy_server: proxy_server.cpp
+	$(CC) $(CFLAGS) -o proxy_server proxy_server.cpp
+
+proxy_client: proxy_client.cpp
+	$(CC) $(CFLAGS) -o proxy_client proxy_client.cpp
+
+proxy_setup: proxy_setup.cpp
+	$(CC) $(CFLAGS) -o proxy_setup proxy_setup.cpp
+
+run: all
+	./direct_setup
+	./proxy_setup
+
+clean:
+	rm -f direct_server direct_client direct_setup proxy_server proxy_client proxy_setup
+

--- a/evaluation/microbenchmarks/cpp_test/README.md
+++ b/evaluation/microbenchmarks/cpp_test/README.md
@@ -1,0 +1,6 @@
+# Comparison between direct client and proxy layer - CPP based
+
+To build the binaries and run the `direct` and `proxy` setups, run:
+```
+make run
+```

--- a/evaluation/microbenchmarks/cpp_test/direct_client.cpp
+++ b/evaluation/microbenchmarks/cpp_test/direct_client.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <string>
+#include <random>
+#include <chrono>
+
+constexpr int N = 1000000;
+constexpr int KEY_SIZE = 16;
+constexpr int VALUE_SIZE = 64;
+
+// Function to generate a random alphanumeric string of given size
+std::string random_string(size_t length) {
+    static const char characters[] =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    static std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<> dist(0, sizeof(characters) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        result += characters[dist(rng)];
+    }
+    return result;
+}
+
+int main() {
+    std::string key = random_string(KEY_SIZE);
+    std::string value = random_string(VALUE_SIZE);
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < N; ++i) {
+        std::cout << key << " " << value << std::endl;
+        std::cout.flush();
+
+        std::string response;
+        std::getline(std::cin, response);
+
+        if (response != "true") {
+            std::cerr << "Unexpected response: " << response << std::endl;
+            break;
+        }
+    }
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+    double elapsed_time = std::chrono::duration<double>(end_time - start_time).count();
+    // print to stderr as the stdout is redirected to the server
+    std::cerr << "Direct client time: " << elapsed_time << " seconds" << std::endl;
+
+    return 0;
+}
+

--- a/evaluation/microbenchmarks/cpp_test/direct_server.cpp
+++ b/evaluation/microbenchmarks/cpp_test/direct_server.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <string>
+
+int main() {
+    std::string input;
+    while (std::getline(std::cin, input)) {
+        std::cout << "true" << std::endl;  // Always respond with "true"
+    }
+    return 0;
+}
+

--- a/evaluation/microbenchmarks/cpp_test/direct_setup.cpp
+++ b/evaluation/microbenchmarks/cpp_test/direct_setup.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <cstdlib>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main() {
+    std::cout << "Starting direct server..." << std::endl;
+
+    // Create pipes for IPC
+    int pipe_client_to_server[2];  // Client writes -> Server reads
+    int pipe_server_to_client[2];  // Server writes -> Client reads
+
+    if (pipe(pipe_client_to_server) == -1 || pipe(pipe_server_to_client) == -1) {
+        std::cerr << "Failed to create pipes" << std::endl;
+        return 1;
+    }
+
+    pid_t server_pid = fork();
+    if (server_pid == 0) {
+        // Server process
+        dup2(pipe_client_to_server[0], STDIN_FILENO);  // Read from client
+        dup2(pipe_server_to_client[1], STDOUT_FILENO); // Write to client
+
+        close(pipe_client_to_server[1]);
+        close(pipe_server_to_client[0]);
+
+        execl("./direct_server", "direct_server", nullptr);
+        std::cerr << "Failed to start server" << std::endl;
+        return 1;
+    }
+
+    pid_t client_pid = fork();
+    if (client_pid == 0) {
+        // Client process
+        dup2(pipe_client_to_server[1], STDOUT_FILENO); // Write to server
+        dup2(pipe_server_to_client[0], STDIN_FILENO);  // Read from server
+
+        close(pipe_client_to_server[0]);
+        close(pipe_server_to_client[1]);
+
+        execl("./direct_client", "direct_client", nullptr);
+        std::cerr << "Failed to start client" << std::endl;
+        return 1;
+    }
+
+    // Close unused pipe ends in the parent process
+    close(pipe_client_to_server[0]);
+    close(pipe_client_to_server[1]);
+    close(pipe_server_to_client[0]);
+    close(pipe_server_to_client[1]);
+
+    // Wait for both child processes to finish
+    waitpid(client_pid, nullptr, 0);
+    waitpid(server_pid, nullptr, 0);
+
+    std::cout << "Direct setup complete." << std::endl;
+    return 0;
+}
+

--- a/evaluation/microbenchmarks/cpp_test/proxy_client.cpp
+++ b/evaluation/microbenchmarks/cpp_test/proxy_client.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <string>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <cstring>
+#include <unistd.h>
+#include <chrono>
+#include <random>
+
+#define PORT 8081  // Proxy server port
+
+constexpr int N = 1000000;
+constexpr int KEY_SIZE = 16;
+constexpr int VALUE_SIZE = 64;
+
+// Function to generate a random alphanumeric string of given size
+std::string random_string(size_t length) {
+    static const char characters[] =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    static std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<> dist(0, sizeof(characters) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        result += characters[dist(rng)];
+    }
+    return result;
+}
+
+int main() {
+    // Create socket
+    int client_socket = socket(AF_INET, SOCK_STREAM, 0);
+    if (client_socket == -1) {
+        std::cerr << "Failed to create socket." << std::endl;
+        return 1;
+    }
+
+    sockaddr_in server_addr {};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(PORT);
+    server_addr.sin_addr.s_addr = INADDR_ANY;
+
+    // Connect to the proxy server
+    if (connect(client_socket, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        std::cerr << "Connection to proxy server failed." << std::endl;
+        return 1;
+    }
+
+    std::string key = random_string(KEY_SIZE);
+    std::string value = random_string(VALUE_SIZE);
+    std::string request = key + " " + value + "\n";
+    size_t request_length = request.length();
+
+    char buffer[1024] = {0};
+    
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < N; ++i) {
+        send(client_socket, request.data(), request_length, 0);
+        
+        ssize_t bytes_received = recv(client_socket, buffer, sizeof(buffer), 0);
+        if (bytes_received <= 0) {
+            std::cerr << "Failed to receive response." << std::endl;
+            break;
+        }
+        
+        if (std::strncmp(buffer, "true", 4) != 0) {
+            std::cerr << "Unexpected response: " << buffer << std::endl;
+        }
+    }
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+    double elapsed_time = std::chrono::duration<double>(end_time - start_time).count();
+    std::cout << "Proxy client time: " << elapsed_time << " seconds" << std::endl;
+
+    close(client_socket);
+    return 0;
+}
+

--- a/evaluation/microbenchmarks/cpp_test/proxy_server.cpp
+++ b/evaluation/microbenchmarks/cpp_test/proxy_server.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <unistd.h>
+#include <string>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <cstring>
+
+#define PROXY_PORT 8081  // Proxy server port
+
+int main() {
+    // Create socket for proxy server
+    int server_socket = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_socket == -1) {
+        std::cerr << "Failed to create socket." << std::endl;
+        return 1;
+    }
+
+    sockaddr_in server_addr {};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = INADDR_ANY;
+    server_addr.sin_port = htons(PROXY_PORT);
+
+    // Bind socket
+    if (bind(server_socket, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        std::cerr << "Bind failed." << std::endl;
+        return 1;
+    }
+
+    // Listen for incoming connections
+    if (listen(server_socket, 3) < 0) {
+        std::cerr << "Listen failed." << std::endl;
+        return 1;
+    }
+
+    std::cout << "Proxy server listening on port " << PROXY_PORT << "..." << std::endl;
+
+    int client_socket = accept(server_socket, nullptr, nullptr);
+    if (client_socket < 0) {
+        std::cerr << "Accept failed." << std::endl;
+        return 1;
+    }
+
+    char buffer[1024];
+    std::string response = "true";
+    size_t response_length = response.length();
+
+    while (true) {
+        ssize_t bytes_received = recv(client_socket, buffer, sizeof(buffer), 0);
+        if (bytes_received <= 0) {
+            break;  // client closed connection or error occurred
+        }
+
+        // Always return "true" as the response
+        send(client_socket, response.data(), response_length, 0);
+    }
+
+    close(client_socket);
+    close(server_socket);
+
+    return 0;
+}

--- a/evaluation/microbenchmarks/cpp_test/proxy_setup.cpp
+++ b/evaluation/microbenchmarks/cpp_test/proxy_setup.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <cstdlib>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main() {
+    std::cout << "Starting proxy setup..." << std::endl;
+
+    pid_t proxy_server_pid = fork();
+    if (proxy_server_pid == 0) {
+        // Proxy server process
+        execl("./proxy_server", "proxy_server", nullptr);
+        std::cerr << "Failed to start proxy server" << std::endl;
+        return 1;
+    }
+
+    // Allow the server to start listening before the client tries to connect
+    sleep(1);  // Wait for the server to start
+
+    pid_t proxy_client_pid = fork();
+    if (proxy_client_pid == 0) {
+        // Proxy client process
+        execl("./proxy_client", "proxy_client", nullptr);
+        std::cerr << "Failed to start proxy client" << std::endl;
+        return 1;
+    }
+
+    // Wait for both child processes to finish
+    waitpid(proxy_client_pid, nullptr, 0);
+    waitpid(proxy_server_pid, nullptr, 0);
+
+    std::cout << "Proxy setup complete." << std::endl;
+    return 0;
+}
+

--- a/evaluation/microbenchmarks/python_test/README.md
+++ b/evaluation/microbenchmarks/python_test/README.md
@@ -1,0 +1,8 @@
+# Comparison between direct client and proxy layer - python based
+ 
+To build the binaries and run the `direct` and `proxy` setups, run:
+```
+python3 direct.py
+python3 proxy.py
+```
+

--- a/evaluation/microbenchmarks/python_test/direct.py
+++ b/evaluation/microbenchmarks/python_test/direct.py
@@ -1,0 +1,56 @@
+import subprocess
+import time
+
+N = 1000000  # Number of queries to send
+
+# Direct server: Always returns "true"
+direct_server_code = """\
+import sys
+
+while True:
+    line = sys.stdin.readline().strip()
+    if not line:
+        break
+    print("true", flush=True)
+"""
+
+# Direct client: Sends random key-value pairs and measures performance
+direct_client_code = f"""\
+import sys, time, random, string
+
+N = {N}
+
+def random_string(size):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=size))
+
+key = random_string(16)
+value = random_string(64)
+
+start_time = time.time()
+for _ in range(N):
+    query = f"{{key}}{{value}}\\n"
+
+    sys.stdout.write(query)
+    sys.stdout.flush()
+
+    response = sys.stdin.readline().strip()
+    assert response == "true", "Unexpected response"
+end_time = time.time()
+# print to stderr as the stdout is redirected to the server
+print(f"Direct client time: {{end_time - start_time:.4f}} seconds", file=sys.stderr)
+"""
+
+def main():
+    print("Starting direct server...")
+    server_proc = subprocess.Popen(["python3", "-c", direct_server_code], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+
+    time.sleep(1)  # Let the server initialize
+
+    print("Starting direct client...")
+    client_proc = subprocess.run(["python3", "-c", direct_client_code], stdin=server_proc.stdout, stdout=server_proc.stdin, text=True)
+
+    server_proc.kill()
+    print("Direct setup complete.")
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/microbenchmarks/python_test/proxy.py
+++ b/evaluation/microbenchmarks/python_test/proxy.py
@@ -1,0 +1,79 @@
+import subprocess
+import time
+
+N = 1000000  # Number of queries to send
+
+# Proxy server: Forwards requests and always returns "true"
+proxy_server_code = """\
+import socket, threading
+
+HOST, PORT = "127.0.0.1", 5000
+
+def handle_client(client_socket):
+    while True:
+        data = client_socket.recv(1024)
+        if not data:
+            break
+        client_socket.sendall(b"true\\n")
+    client_socket.close()
+
+def main():
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.bind((HOST, PORT))
+    server_socket.listen(5)
+    
+    print("Proxy server listening on", HOST, PORT)
+    
+    while True:
+        client_socket, _ = server_socket.accept()
+        threading.Thread(target=handle_client, args=(client_socket,)).start()
+
+if __name__ == "__main__":
+    main()
+"""
+
+# Proxy client: Sends queries via the proxy
+proxy_client_code = f"""\
+import socket, time, random, string
+
+N = {N}
+PROXY_HOST, PROXY_PORT = "127.0.0.1", 5000
+
+def random_string(size):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=size))
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.connect((PROXY_HOST, PROXY_PORT))
+
+key = random_string(16)
+value = random_string(64)
+start_time = time.time()
+
+for _ in range(N):    
+    query = f"{{key}}{{value}}\\n".encode()
+
+    sock.sendall(query)
+    response = sock.recv(1024).decode().strip()
+    assert response == "true", "Unexpected response"
+
+end_time = time.time()
+print(f"Proxy client time: {{end_time - start_time:.4f}} seconds")
+
+sock.close()
+"""
+
+def main():
+    print("Starting proxy server...")
+    proxy_proc = subprocess.Popen(["python3", "-c", proxy_server_code])
+
+    time.sleep(1)  # Let the server initialize
+
+    print("Starting proxy client...")
+    client_proc = subprocess.run(["python3", "-c", proxy_client_code])
+
+    proxy_proc.kill()
+    print("Proxy setup complete.")
+
+if __name__ == "__main__":
+    main()
+

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,8 @@
             libguestfs
             guestfs-tools
             gdb
+            zmqpp
+            zeromq
             #for the kernel module build
             # cpuid
             # dmidecode

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -108,6 +108,7 @@ def safe_receive(socket, size):
 def send_queries(server_address, server_port, queries, latency_results, config_path, client_num):
     # Open a connection to the server
     client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     client_socket.connect((server_address, server_port))
 
     # Load and send default policy
@@ -165,7 +166,7 @@ def main():
   parser.add_argument('--address', help='IP address of the server to connect', default="127.0.0.1", required=False, type=str)
   parser.add_argument('--port', help='Port of the running server to connect', default=1312, required=False, type=int)
   parser.add_argument('--clients', help='Number of clients to spawn', default=1, type=int)
-  parser.add_argument('--value_size', help='Size of the value in bytes for PUT queries', default=1024, type=int)
+  parser.add_argument('--value_size', help='Size of the value in bytes for PUT queries', default=64, type=int)
   args = parser.parse_args()
 
   # Perform the load phase of the workload

--- a/scripts/direct_client.py
+++ b/scripts/direct_client.py
@@ -100,7 +100,7 @@ def main():
   parser.add_argument('--db', help='Database type (redis or rocksdb)', required=True, type=str, choices=["redis", "rocksdb"])
   parser.add_argument('--db_address', help='Address of the database server', required=True, type=str)
   parser.add_argument('--clients', help='Number of clients to spawn', default=1, type=int)
-  parser.add_argument('--value_size', help='Size of the value in bytes for PUT queries', default=1024, type=int)
+  parser.add_argument('--value_size', help='Size of the value in bytes for PUT queries', default=64, type=int)
   args = parser.parse_args()
 
   # Perform the load phase of the workload


### PR DESCRIPTION
This PR performs the following:

- Add IPC microbenchmarks for the proxy in the `evaluation` directory
- Modifies controller sockets to use `iovec`

Here are some of the acquired numbers to justify the performance drop between `direct_client` vs having a `proxy` layer:
# Performance Breakdown: Direct vs. Passthrough Communication

## **1. Performance Analysis**
### **Passthrough Mode**
| Component                | Time (seconds) | Percentage  |
|--------------------------|---------------|-------------|
| Query Preparation Time   | 0.230         | 0.43%       |
| Network Send Time        | 7.527         | 14.12%      |
| Wait and Receive Time    | 45.563        | 85.45%      |

### **Direct Mode**
| Component                | Time (seconds) | Percentage  |
|--------------------------|---------------|-------------|
| Query Preparation Time   | 0.189         | 0.50%       |
| Send Time (stdin)        | 1.825         | 4.84%       |
| Wait and Receive Time    | 35.690        | 94.66%      |

---

## **2. Performance Without Server Interaction**
(When returning successfully without DB interaction)

### **Passthrough Mode**
| Component                | Time (seconds) | Percentage  |
|--------------------------|---------------|-------------|
| Query Preparation Time   | 0.228         | 0.92%       |
| Network Send Time        | 7.061         | 28.59%      |
| Wait and Receive Time    | 17.409        | 70.49%      |

### **Direct Mode**
| Component                | Time (seconds) | Percentage  |
|--------------------------|---------------|-------------|
| Query Preparation Time   | 0.126         | 1.97%       |
| Send Time (stdin)        | 1.870         | 29.36%      |
| Wait and Receive Time    | 4.373         | 68.66%      |

---

## **3. Benchmark Breakdown**
Workload: **workloada medium**, Value Size: **64B**, 1 Client

### **Direct Mode**
| Metric                    | Time (seconds) |
|---------------------------|---------------|
| **Total**                 | 37.7572       |
| Query Operations          | 33.6405       |
| Stdin/Stdout Write Time   | 4.11674       |

### **Passthrough Mode**
| Metric                    | Time (seconds) |
|---------------------------|---------------|
| **Total**                 | 58.2577       |
| Query Operations          | 30.2184       |
| Socket Communication Time | 28.0393       |

🔹 **Observation**:  
The overhead is caused primarily by **socket communication** (1 additional RTT).  
Even optimizations like different encoding and `iovec` yielded **no significant improvement** due to **syscall overhead**.

---

## **4. Large Message Performance (2048B)**
| Mode         | Elapsed Time (seconds) |
|-------------|-----------------------|
| **Direct**   | 49.886                |
| **Passthrough** | 57.779               |

## **5. High Concurrency (16 Clients, 2048B)**
| Mode         | Elapsed Time (seconds) |
|-------------|-----------------------|
| **Direct**   | 15.036                |
| **Passthrough** | 14.830               |

🔹 **Observation**:  
For **small messages**, the overhead is more significant.  
For **large messages and high concurrency**, the overhead is **minimized**, and parallel socket communication benefits start to show.

---

## **6. IPC Performance (Using `ipc-bench`)**
### **Message Size: 64B**
| IPC Mechanism  | Runtime (seconds) | Throughput (msg/s) |
|---------------|----------------|------------------|
| **Pipe**      | 19.0           | 52,453          |
| **TCP**       | 21.0           | 47,484          |
| **Domain**    | 9.9            | 100,656         |

### **Message Size: 1024B**
| IPC Mechanism  | Runtime (seconds) | Throughput (msg/s) |
|---------------|----------------|------------------|
| **Pipe**      | 19.1           | 52,326          |
| **TCP**       | 21.3           | 46,828          |
| **Domain**    | 10.8           | 92,636          |

### **Message Size: 4096B**
| IPC Mechanism  | Runtime (seconds) | Throughput (msg/s) |
|---------------|----------------|------------------|
| **Pipe**      | 17.9           | 55,816          |
| **TCP**       | 23.3           | 42,839          |
| **Domain**    | 12.9           | 77,299          |

🔹 **Observation**:  
- **Domain sockets** outperform both TCP and pipes significantly.
- **Pipes** are slightly faster than **TCP** for small messages but do not scale as well.
- **TCP performance degrades** as message size increases.

---

## **7. Reasons for Using a Proxy**
1. **Security & Isolation**:  
   - Better control over clients  
   - Enables rate limiting and logging  

2. **Scalability**:  
   - Simplifies handling multiple clients  

3. **Protocol Flexibility**:  
   - Allows support for network-based clients  

4. **Separation of Concerns**:  
   - Keeps the core server logic independent of input methods  

---

## **8. Potential Optimizations**
✔ **Batch Queries for Throughput** (currently 1-1 query-response model)  
✔ **Busy Waiting** (reduce syscall overhead at the cost of CPU usage)  

⚠ **However, we do not claim to optimize network usage.**  
