### PR TITLE
GDPR metadata cache design and testing

### DIFF
--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -13,7 +13,7 @@ constexpr int s2ns = 1000000000;
 constexpr int s2ms = 1000;
 constexpr int ns_precision = 9;
 
-constexpr int max_msg_size = 4096;
+constexpr int max_msg_size = 8192;
 constexpr size_t msg_header_size = sizeof(uint32_t);
 
 // controller response codes

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -32,7 +32,7 @@ using controller::gdpr_regulator;
 
 #ifdef METADATA_CACHE
 // Define the cache size (in keys)
-static constexpr size_t GDPR_METADATA_CACHE_SIZE = 10000;
+static constexpr size_t GDPR_METADATA_CACHE_SIZE = (1 << 16); // 65536 cached keys / 1024 per shard
 static auto& cache = controller::GdprMetadataCache::get_instance(GDPR_METADATA_CACHE_SIZE);
 #endif
 
@@ -72,6 +72,12 @@ auto receive_policy(int socket) -> std::optional<default_policy>
   return default_policy(client_policy);
 }
 
+// Possible cases:
+// 1. Key does not exist in cache or DB            (cache miss + DB miss) -> {monitor, ""}, is_valid = false
+// 2. Key is in cache, but validation fails        (cache hit, no DB lookup) -> {monitor, std::nullopt}, is_valid = false
+// 3. Key is in cache, validation succeeds         (cache hit, no DB lookup) -> {monitor, std::nullopt}, is_valid = true
+// 4. Key is not in cache, found in DB, invalid    (cache miss + DB hit) -> {monitor, res}, is_valid = false
+// 5. Key is not in cache, found in DB, valid      (cache miss + DB hit) -> {monitor, res}, is_valid = true
 auto filter_and_monitor(const std::unique_ptr<kv_client>& client,
   const query& query_args,
   const default_policy& def_policy,
@@ -85,23 +91,17 @@ auto filter_and_monitor(const std::unique_ptr<kv_client>& client,
     auto filter = std::make_shared<gdpr_filter>(*cached_metadata);
     is_valid = filter->validate(query_args, def_policy);
     auto monitor = gdpr_monitor(filter, query_args, def_policy);
-    return {monitor, std::nullopt};
+    return {monitor, std::nullopt};  // Cache hit, no DB data returned
   }
   #endif
 
-  // Fetch data from client if not in cache or cache is disabled
+  // Fetch data from client if not in cache
   auto res = client->gdpr_get(query_args.key());
   auto filter = std::make_shared<gdpr_filter>(res);
   is_valid = filter->validate(query_args, def_policy);
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
   return {monitor, res};
-
-// Possible cases:
-// 1. Key does not exist in cache or DB            (cache miss + DB miss) -> {monitor, ""}, is_valid = false
-// 2. Key is in cache, but validation fails        (cache hit, no DB lookup) -> {monitor, std::nullopt}, is_valid = false
-// 3. Key is in cache, validation succeeds         (cache hit, no DB lookup) -> {monitor, std::nullopt}, is_valid = true
-// 4. Key is not in cache, found in DB, invalid    (cache miss + DB hit) -> {monitor, res}, is_valid = false
-// 5. Key is not in cache, found in DB, valid      (cache miss + DB hit) -> {monitor, res}, is_valid = true
+  
 }
 
 // Helper function to update cache with new metadata
@@ -124,17 +124,16 @@ auto handle_get(const std::unique_ptr<kv_client>& client,
                 const query& query_args,
                 const default_policy& def_policy) -> std::string
 {
-  bool query_is_valid;
-  // Get monitor, and optionally fetch data
-  auto [monitor, res] = filter_and_monitor(client, query_args, def_policy, query_is_valid);
-  // Log the operation (if needed)
-  monitor.monitor_query(query_is_valid);
+  // Always fetch from database as even in cache hit, we need to fetch the value
+  auto res = client->gdpr_get(query_args.key());
+  auto filter = std::make_shared<gdpr_filter>(res);
+  bool is_valid = filter->validate(query_args, def_policy);
+  
+  // Create monitor and log
+  auto monitor = gdpr_monitor(filter, query_args, def_policy);
+  monitor.monitor_query(is_valid);
 
-  if (query_is_valid) {
-    if (!res) {
-      // Fetch data in case of a cache hit
-      res = client->gdpr_get(query_args.key());
-    }
+  if (is_valid && res) {
     return controller::remove_gdpr_metadata(std::move(res.value()));
   }
 
@@ -146,9 +145,8 @@ auto handle_put(const std::unique_ptr<kv_client>& client,
                 const default_policy& def_policy) -> std::string
 {
   bool query_is_valid;
-  // Get monitor, and optionally fetch data
   auto [monitor, res] = filter_and_monitor(client, query_args, def_policy, query_is_valid);
-
+  
   if (!res) {
     // Handle new key insertion
     query_rewriter rewriter(query_args, def_policy, query_args.value());
@@ -156,8 +154,11 @@ auto handle_put(const std::unique_ptr<kv_client>& client,
     auto ret_val = client->gdpr_put(query_args.key(), rewriter.new_value());
 
     if (ret_val) {
-      // Update cache and return success
-      update_cache(query_args.key(), std::move(rewriter.new_value()));
+      #ifdef METADATA_CACHE
+      // Extract and cache metadata - move to avoid copy
+      std::string metadata = controller::preserve_only_gdpr_metadata(rewriter.new_value());
+      cache.cache_put(query_args.key(), std::move(metadata));
+      #endif
       return PUT_SUCCESS;
     }
   } else if (query_is_valid) {
@@ -167,8 +168,11 @@ auto handle_put(const std::unique_ptr<kv_client>& client,
     auto ret_val = client->gdpr_put(query_args.key(), rewriter.new_value());
 
     if (ret_val) {
-      // Update cache and return success
-      update_cache(query_args.key(), std::move(rewriter.new_value()));
+      #ifdef METADATA_CACHE
+      // Update cache with new metadata - move to avoid copy
+      std::string metadata = controller::preserve_only_gdpr_metadata(rewriter.new_value());
+      cache.cache_put(query_args.key(), std::move(metadata));
+      #endif
       return PUT_SUCCESS;
     }
   } else {
@@ -184,18 +188,18 @@ auto handle_delete(const std::unique_ptr<kv_client>& client,
                   const default_policy& def_policy) -> std::string
 {
   bool query_is_valid;
-  // Get monitor, and optionally fetch data
   auto [monitor, res] = filter_and_monitor(client, query_args, def_policy, query_is_valid);
 
   // Log the operation (if needed)
   monitor.monitor_query(query_is_valid);
 
   if (query_is_valid) {
-    // Perform deletion if valid
     auto ret_val = client->gdpr_del(query_args.key());
     if (ret_val) {
-      // Remove from cache and return success
-      remove_from_cache(query_args.key());
+      #ifdef METADATA_CACHE
+      // Remove from cache
+      cache.cache_remove(query_args.key());
+      #endif
       return DELETE_SUCCESS;
     }
   }
@@ -408,7 +412,12 @@ auto handle_connection
   #ifdef DEBUG
   std::cout << "Total query processing time: " << total_query_time.count() << " seconds\n";
   #endif
-
+  #ifdef CACHE_STATS
+  std::cout << "Cache size: " << cache.total_size() << "\n";
+  std::cout << "Cache hits: " << cache.cache_hits() << "\n";
+  std::cout << "Cache misses: " << cache.cache_misses() << "\n";
+  std::cout << "Cache hit rate: " << cache.cache_hit_rate() * 100 << "%\n";
+  #endif
   // Unmap the socket communication buffer
   munmap(buffer, max_msg_size);
   // Close the client socket

--- a/controller/source/global_gdpr_metadata_cache.hpp
+++ b/controller/source/global_gdpr_metadata_cache.hpp
@@ -3,236 +3,164 @@
 #include <string>
 #include <unordered_map>
 #include <shared_mutex>
-#include <optional>
-#include <list>
-#include <algorithm>
-#include <memory>
 #include <atomic>
-
-#include "gdpr_metadata.hpp"
+#include <memory>
+#include <array>
+#include <string_view>
+#include <random>
 
 namespace controller {
 
-/**
- * @brief Template class for a thread-safe LRU cache for GDPR metadata
- * 
- * This class implements a fixed-size cache with O(1) lookup, insertion, and deletion
- * operations. It uses a reader/writer lock for thread safety with multiple readers
- * and single writer.
- * 
- * @tparam T The type of metadata to be cached
- */
 template <typename T>
-class GlobalGdprMetadataCache {
-public:
-  struct string_hash {
-    using is_transparent = void;
-    size_t operator()(const std::string& str) const { return std::hash<std::string>{}(str); }
-    size_t operator()(std::string_view sv) const { return std::hash<std::string_view>{}(sv); }
-  };
-  
-  /**
-   * @brief Constructs a new GlobalGdprMetadataCache with specified capacity
-   * 
-   * @param capacity Maximum number of items to store in the cache
-   */
-  #ifdef CACHE_STATS
-  explicit GlobalGdprMetadataCache(size_t capacity) 
-      : m_capacity(capacity), 
-        m_curr_size(0),
-        m_hits(0),
-        m_misses(0) {}
-  #else
-  explicit GlobalGdprMetadataCache(size_t capacity) 
-      : m_capacity(capacity), 
-        m_curr_size(0) {}
-  #endif
-
-  /**
-   * @brief Get metadata for a given key if it exists in the cache
-   * 
-   * @param key The key to lookup
-   * @return std::optional<T> The metadata if found, std::nullopt otherwise
-   */
-  auto cache_get(std::string_view key) -> std::optional<T> {
-    std::shared_lock<std::shared_mutex> lock(m_mutex);
+class ShardedGdprMetadataCache {
+private:
+    static constexpr size_t NUM_SHARDS = 64;  // Power of 2 for efficient mod
     
-    auto it = m_cache_map.find(key);
-    if (it != m_cache_map.end()) {
-      // Move the accessed item to the front of the list (most recently used)
-      // m_cache_list.splice(m_cache_list.begin(), m_cache_list, it->second.list_it);
+    struct CacheEntry {
+      std::shared_ptr<const T> data;
+    };
+    
+    struct Shard {
+      std::unordered_map<std::string, CacheEntry> entries;
+      std::shared_mutex mutex;  // Fine-grained per-shard locking
+      std::atomic<size_t> size{0};
+      mutable std::mt19937 rng{std::random_device{}()};  // For random eviction
+    };
+    
+    std::array<Shard, NUM_SHARDS> shards;
+    const size_t max_size_per_shard;
+    
+    size_t get_shard_index(std::string_view key) const noexcept {
+      return std::hash<std::string_view>{}(key) % NUM_SHARDS;
+    }
+
+    // Cache hit/miss counters for performance tracking
+    mutable std::atomic<uint64_t> m_hits;
+    mutable std::atomic<uint64_t> m_misses;
+
+public:
+    // Singleton instance getter
+    static ShardedGdprMetadataCache<T>& get_instance(size_t capacity = (1 << 16)) {
+      static ShardedGdprMetadataCache<T> cache_instance(capacity);
+      return cache_instance;
+    }
+
+    explicit ShardedGdprMetadataCache(size_t total_capacity) 
+      : m_hits(0), 
+        m_misses(0),
+        max_size_per_shard((total_capacity + NUM_SHARDS - 1) / NUM_SHARDS) {}
+    
+    // Get metadata - returns shared_ptr to avoid copying
+    std::shared_ptr<const T> cache_get(std::string_view key) {
+
+      auto& shard = shards[get_shard_index(key)];
+      std::shared_lock<std::shared_mutex> lock(shard.mutex);
+      
+      auto it = shard.entries.find(std::string(key));
+      if (it != shard.entries.end()) {
+        #ifdef CACHE_STATS
+        m_hits.fetch_add(1, std::memory_order_relaxed);
+        #endif
+        return it->second.data;
+      }
+
       #ifdef CACHE_STATS
-      m_hits.fetch_add(1, std::memory_order_relaxed);
+      m_misses.fetch_add(1, std::memory_order_relaxed);
       #endif
-      return it->second.gdpr_metadata;
+      
+      return nullptr;
     }
     
+    // Put metadata - moves data to avoid copying
+    void cache_put(std::string_view key, T&& metadata) {
+
+      auto& shard = shards[get_shard_index(key)];
+      std::unique_lock<std::shared_mutex> lock(shard.mutex);
+      
+      std::string key_str(key);
+      auto it = shard.entries.find(key_str);
+      
+      if (it != shard.entries.end()) {
+        // Update existing entry
+        it->second.data = std::make_shared<const T>(std::move(metadata));
+      } else {
+        // Add new entry, evict if necessary
+        if (shard.size.load(std::memory_order_relaxed) >= max_size_per_shard) {
+          random_evict_from_shard(shard);  // O(1) random eviction
+        }
+        
+        CacheEntry entry;
+        entry.data = std::make_shared<const T>(std::move(metadata));
+        
+        shard.entries.emplace(std::move(key_str), std::move(entry));
+        shard.size.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+    
+    // Remove from cache
+    bool cache_remove(std::string_view key) {
+
+        auto& shard = shards[get_shard_index(key)];
+        std::unique_lock<std::shared_mutex> lock(shard.mutex);  // Exclusive lock
+        
+        auto it = shard.entries.find(std::string(key));
+        if (it != shard.entries.end()) {
+            shard.entries.erase(it);
+            shard.size.fetch_sub(1, std::memory_order_relaxed);
+            return true;
+        }
+        return false;
+    }
+    
+    // Statistics
+    size_t total_size() const {
+      size_t total = 0;
+      for (const auto& shard : shards) {
+        total += shard.size.load(std::memory_order_relaxed);
+      }
+      return total;
+    }
+    
+    size_t capacity() const noexcept {
+      return max_size_per_shard * NUM_SHARDS;
+    }
+
     #ifdef CACHE_STATS
-    m_misses.fetch_add(1, std::memory_order_relaxed);
+    [[nodiscard]] auto cache_hit_rate() const -> double {
+      uint64_t hits = m_hits.load(std::memory_order_relaxed);
+      uint64_t misses = m_misses.load(std::memory_order_relaxed);
+      uint64_t total = hits + misses;
+      return total > 0 ? static_cast<double>(hits) / total : 0.0;
+    }
+
+    [[nodiscard]] auto cache_hits() const -> uint64_t {
+      return m_hits.load(std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] auto cache_misses() const -> uint64_t {
+      return m_misses.load(std::memory_order_relaxed);
+    }
     #endif
 
-    return std::nullopt;
-  }
-
-  /**
-   * @brief Insert or update metadata for a given key
-   * 
-   * @param key The key to insert or update
-   * @param gdpr_metadata The metadata to store
-   */
-  auto cache_put(std::string_view key, T gdpr_metadata) -> void {
-    std::unique_lock<std::shared_mutex> lock(m_mutex);
-    
-    auto it = m_cache_map.find(key);
-    if (it != m_cache_map.end()) {
-      // Key exists, update its gdpr_metadata and move it to the front
-      it->second.gdpr_metadata = std::move(gdpr_metadata);
-      m_cache_list.splice(m_cache_list.begin(), m_cache_list, it->second.list_it);
-      return;
-    }
-    
-    // If cache is at capacity, remove the least recently used item
-    if (m_curr_size >= m_capacity) {
-      auto last = m_cache_list.back();
-      m_cache_map.erase(last);
-      m_cache_list.pop_back();
-      --m_curr_size;
-    }
-    
-    // Insert new item at the front
-    std::string key_str(key);  // Convert to std::string
-    m_cache_list.push_front(key_str);
-    m_cache_map[key_str] = {std::move(gdpr_metadata), m_cache_list.begin()};
-    ++m_curr_size;
-  }
-
-  /**
-   * @brief Remove an item from the cache
-   * 
-   * @param key The key to remove
-   * @return true if the key was found and removed, false otherwise
-   */
-  auto cache_remove(std::string_view key) -> bool {
-    std::unique_lock<std::shared_mutex> lock(m_mutex);
-    
-    auto it = m_cache_map.find(key);
-    if (it != m_cache_map.end()) {
-      m_cache_list.erase(it->second.list_it);
-      m_cache_map.erase(it);
-      --m_curr_size;
-      return true;
-    }
-    
-    return false;
-  }
-
-  /**
-   * @brief Clear all items from the cache
-   */
-  auto cache_clear() -> void {
-    std::unique_lock<std::shared_mutex> lock(m_mutex);
-    m_cache_map.clear();
-    m_cache_list.clear();
-    m_curr_size = 0;
-  }
-
-  /**
-   * @brief Get the current size of the cache
-   * 
-   * @return size_t The number of items in the cache
-   */
-  [[nodiscard]] auto cache_curr_size() const -> size_t {
-    std::shared_lock<std::shared_mutex> lock(m_mutex);
-    return m_curr_size;
-  }
-
-  /**
-   * @brief Get the capacity of the cache
-   * 
-   * @return size_t The maximum number of items the cache can hold
-   */
-  [[nodiscard]] auto cache_capacity() const -> size_t {
-    return m_capacity;
-  }
-
-  #ifdef CACHE_STATS
-  /**
-   * @brief Get the hit rate of the cache
-   * 
-   * @return double The percentage of successful lookups
-   */
-  [[nodiscard]] auto cache_hit_rate() const -> double {
-    uint64_t hits = m_hits.load(std::memory_order_relaxed);
-    uint64_t misses = m_misses.load(std::memory_order_relaxed);
-    uint64_t total = hits + misses;
-    return total > 0 ? static_cast<double>(hits) / total : 0.0;
-  }
-
-  /**
-   * @brief Get the number of cache hits
-   * 
-   * @return uint64_t The number of cache hits
-   */
-  [[nodiscard]] auto cache_hits() const -> uint64_t {
-    return m_hits.load(std::memory_order_relaxed);
-  }
-
-  /**
-   * @brief Get the number of cache misses
-   * 
-   * @return uint64_t The number of cache misses
-   */
-  [[nodiscard]] auto cache_misses() const -> uint64_t {
-    return m_misses.load(std::memory_order_relaxed);
-  }
-  #endif
-
-  /**
-   * @brief Singleton instance getter
-   * 
-   * @param capacity The capacity for the cache (only used on first call)
-   * @return A reference to the singleton cache instance
-   */
-  static auto get_instance(size_t capacity = 1024) -> GlobalGdprMetadataCache<T>& {
-    static GlobalGdprMetadataCache<T> cache_instance(capacity);
-    return cache_instance;
-  }
-
 private:
-  // Cache entry structure
-  struct CacheEntry {
-    T gdpr_metadata;
-    typename std::list<std::string>::iterator list_it;
-  };
-
-  // Maximum capacity of the cache
-  size_t m_capacity;
-  
-  // Current size of the cache
-  size_t m_curr_size;
-  
-  #ifdef CACHE_STATS
-  // Cache hit/miss counters for performance tracking
-  mutable std::atomic<uint64_t> m_hits;
-  mutable std::atomic<uint64_t> m_misses;
-  #endif
-  
-  // LRU list to track item usage order (most recent at front)
-  mutable std::list<std::string> m_cache_list;
-  
-  // Map for O(1) lookups
-  std::unordered_map<std::string, CacheEntry, string_hash, std::equal_to<>> m_cache_map;
-  
-  // Reader/writer lock for thread safety
-  mutable std::shared_mutex m_mutex;
+    // O(1) random eviction - much faster than LFU
+    void random_evict_from_shard(Shard& shard) {
+      
+      if (shard.entries.empty()) return;
+      
+      // Generate random index
+      std::uniform_int_distribution<size_t> dist(0, shard.entries.size() - 1);
+      size_t random_index = dist(shard.rng);
+      
+      // Find iterator at random position
+      auto it = shard.entries.begin();
+      std::advance(it, random_index);
+      
+      shard.entries.erase(it);
+      shard.size.fetch_sub(1, std::memory_order_relaxed);
+    }
 };
 
-/**
- * @brief Typedef for the GDPR metadata cache
- * 
- * This defines the specific type of metadata cache used in the application.
- * Can be modified to accommodate different metadata types in the future.
- */
-using GdprMetadataCache = GlobalGdprMetadataCache<std::string>;
+using GdprMetadataCache = ShardedGdprMetadataCache<std::string>;
 
 } // namespace controller

--- a/evaluation/VM/direct.sh
+++ b/evaluation/VM/direct.sh
@@ -19,7 +19,7 @@ fi
 
 # compile the controller in the CVM with the appropriate encryption option
 virt-customize --add ${images_dir}/gdpr.img --smp $(nproc) --memsize 16384 \
-  --run-command "cd /root/GDPRuler/controller && rm -rf build && cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D ENCRYPTION_ENABLED=$encryption && cmake --build build -j$(nproc)"
+  --run-command "cd /root/GDPRuler/controller && rm -rf build && cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D METADATA_CACHE=ON -D CACHE_STATS=OFF -D ENCRYPTION_ENABLED=$encryption && cmake --build build -j$(nproc)"
 
 # GDPR controller
 results_csv_file=${script_dir}/results/direct_CVM-query_mgmt_${workload_type}-encryption_$encryption-logging_$logging-connection_${server_connection}.csv

--- a/evaluation/VM/gdpr.sh
+++ b/evaluation/VM/gdpr.sh
@@ -38,7 +38,7 @@ fi
 
 # compile the controller in the CVM with the appropriate encryption option
 virt-customize --add ${images_dir}/gdpr.img --smp $(nproc) --memsize 16384 \
-  --run-command "cd /root/GDPRuler/controller && rm -rf build && cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D ENCRYPTION_ENABLED=$encryption && cmake --build build -j$(nproc)"
+  --run-command "cd /root/GDPRuler/controller && rm -rf build && cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D METADATA_CACHE=ON -D CACHE_STATS=OFF -D ENCRYPTION_ENABLED=$encryption && cmake --build build -j$(nproc)"
 
 # GDPR controller
 results_csv_file=${script_dir}/results/gdpr_CVM-query_mgmt_${workload_type}-encryption_$encryption-logging_$logging-connection_${server_connection}.csv

--- a/evaluation/VM/passthrough.sh
+++ b/evaluation/VM/passthrough.sh
@@ -19,7 +19,7 @@ fi
 
 # compile the controller in the CVM with the appropriate encryption option
 virt-customize --add ${images_dir}/gdpr.img --smp $(nproc) --memsize 16384 \
-  --run-command "cd /root/GDPRuler/controller && rm -rf build && cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D ENCRYPTION_ENABLED=$encryption && cmake --build build -j$(nproc)"
+  --run-command "cd /root/GDPRuler/controller && rm -rf build && cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D METADATA_CACHE=ON -D CACHE_STATS=OFF -D ENCRYPTION_ENABLED=$encryption && cmake --build build -j$(nproc)"
 
 # GDPR controller
 results_csv_file=${script_dir}/results/passthrough_CVM-query_mgmt_${workload_type}-encryption_$encryption-logging_$logging-connection_${server_connection}.csv

--- a/evaluation/args_and_checks.sh
+++ b/evaluation/args_and_checks.sh
@@ -96,7 +96,7 @@ parse_args_and_checks() {
   # Build the controller
   echo "Building controller with encryption set to $encryption"
   pushd ${project_root}/controller
-  cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D DEBUG_FLAG=OFF -D METADATA_CACHE=OFF -D ASAN_ENABLED=OFF -D ENCRYPTION_ENABLED=$encryption;
+  cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D DEBUG_FLAG=OFF -D METADATA_CACHE=ON -D CACHE_STATS=OFF -D ASAN_ENABLED=OFF -D ENCRYPTION_ENABLED=$encryption;
   cmake --build build -j$(nproc)
   popd
 }

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -179,7 +179,7 @@ def create_client_process(server_address, server_port, queries, latency_results,
 
 def main():
   parser = argparse.ArgumentParser(description='Start a client.')
-  parser.add_argument('--config', help='Path to config file or directory containing client configs for the GDPR case. Leave empty for passthrough case', required=True, type=str)
+  parser.add_argument('--config', help='Path to config file or directory containing client configs for the GDPR case. Provide "no_cfg" for passthrough case', required=True, type=str)
   parser.add_argument('--workload', help='Name of the workload trace', required=True, type=str, choices=get_workload_options())
   parser.add_argument('--address', help='IP address of the server to connect', default="127.0.0.1", required=False, type=str)
   parser.add_argument('--port', help='Port of the running server to connect', default=1312, required=False, type=int)


### PR DESCRIPTION
Adjust the gdpr metadata cache to 
- use a sharded design
- enforce random eviction when full
- used only in `put`s to avoid re-fetching the data
- integration in the automation