### PR TITLE
Dimstav23/finalize metadata encoding

### DIFF
--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -2,6 +2,9 @@
 
 #include <vector>
 #include <string>
+#include <string_view>
+#include <sstream>
+#include <iomanip>
 #include <span>
 #include <unistd.h>
 #include <sys/socket.h>
@@ -102,4 +105,62 @@ auto inline safe_sock_receive(int socket, void* buffer) -> ssize_t {
   msg.msg_iovlen = 1;
 
   return recvmsg(socket, &msg, MSG_WAITALL);
+}
+
+/* Debug printing functions for binary data */
+/**
+ * Creates a hex dump of binary data with optional ASCII representation
+ * 
+ * @param data The binary data to dump (string or string_view)
+ * @param show_ascii Whether to show ASCII representation alongside hex
+ * @param bytes_per_line Number of bytes to display per line (default: 16)
+ * @return String containing the formatted hex dump
+ */
+auto hex_dump(std::string_view data, bool show_ascii = true, size_t bytes_per_line = 16) -> std::string {
+  std::stringstream hex;
+  
+  hex << "=== HEX DUMP ===\n";
+  hex << "Size: " << data.size() << " bytes\n";
+  
+  for (size_t i = 0; i < data.size(); ++i) {
+    // Print offset at start of each line
+    if (i % bytes_per_line == 0) {
+      hex << std::hex << std::setw(4) << std::setfill('0') << i << ": ";
+    }
+    
+    // Print hex value
+    hex << std::hex << std::setw(2) << std::setfill('0') 
+        << static_cast<int>(static_cast<uint8_t>(data[i])) << " ";
+    
+    // End of line or end of data
+    if (i % bytes_per_line == bytes_per_line - 1 || i == data.size() - 1) {
+      // Add padding if not a full line
+      if (i % bytes_per_line != bytes_per_line - 1) {
+        size_t padding = (bytes_per_line - 1 - (i % bytes_per_line)) * 3;
+        hex << std::string(padding, ' ');
+      }
+      
+      // Add ASCII representation if requested
+      if (show_ascii) {
+        hex << " |";
+        size_t line_start = i - (i % bytes_per_line);
+        size_t line_end = std::min(line_start + bytes_per_line, data.size());
+        
+        for (size_t j = line_start; j < line_end; ++j) {
+          char c = data[j];
+          hex << (std::isprint(c) ? c : '.');
+        }
+        hex << "|";
+      }
+      
+      hex << "\n";
+    }
+  }
+  
+  return hex.str();
+}
+
+// Overload for std::string (automatically converts to string_view)
+auto hex_dump(const std::string& data, bool show_ascii = true, size_t bytes_per_line = 16) -> std::string{
+  return hex_dump(std::string_view(data), show_ascii, bytes_per_line);
 }

--- a/controller/source/common.hpp
+++ b/controller/source/common.hpp
@@ -28,9 +28,11 @@ constexpr std::string DELETE_FAILED    = "4";
 constexpr std::string GETM_FAILED      = "5";
 constexpr std::string PUTM_SUCCESS     = "6";
 constexpr std::string PUTM_FAILED      = "7";
-constexpr std::string GET_LOGS_FAILED  = "8";
-constexpr std::string INVALID_COMMAND  = "9";
-constexpr std::string UNKNOWN_ERROR    = "10";
+constexpr std::string PUTC_SUCCESS     = "8";
+constexpr std::string PUTC_FAILED      = "9";
+constexpr std::string GET_LOGS_FAILED  = "10";
+constexpr std::string INVALID_COMMAND  = "11";
+constexpr std::string UNKNOWN_ERROR    = "12";
 
 /* Parse the value corresponding to given option. Return empty string if not found. */
 auto inline get_command_line_argument(const auto& args, const std::string& option) -> std::string

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -102,7 +102,15 @@ auto filter_and_monitor(const std::unique_ptr<kv_client>& client,
   auto metadata_or_value = client->gdpr_get(query_args.key());
   #endif
 
-  // Create filter and monitor objects and validate the query
+  if (!metadata_or_value) {
+    // if the key does not exist in cache or DB
+    is_valid = true;
+    auto monitor = gdpr_monitor(query_args, def_policy);
+    return {std::move(monitor), std::nullopt};
+  }
+
+  // if the key exists in cache or DB
+  // Create a filter and monitor object and validate the query
   gdpr_filter filter(metadata_or_value);
   is_valid = filter.validate(query_args, def_policy);
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
@@ -193,6 +201,11 @@ inline auto handle_delete(const std::unique_ptr<kv_client>& client,
   bool cache_hit = false;
   auto [monitor, metadata_or_value] = filter_and_monitor(client, query_args, def_policy, query_is_valid, cache_hit);
 
+  if (!metadata_or_value) {
+    // Key does not exist in cache or DB - try to delete non-existing key
+    monitor.monitor_query(false);
+    return DELETE_FAILED;
+  }
   // Log the operation (if needed)
   monitor.monitor_query(query_is_valid);
 

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -32,7 +32,7 @@ using controller::gdpr_regulator;
 
 #ifdef METADATA_CACHE
 // Define the cache size (in keys)
-static constexpr size_t GDPR_METADATA_CACHE_SIZE = (1 << 16); // 65536 cached keys / 1024 per shard
+static constexpr size_t GDPR_METADATA_CACHE_SIZE = (1 << 20); // 1048576 cached keys / 16384 per shard
 static auto& cache = controller::GdprMetadataCache::get_instance(GDPR_METADATA_CACHE_SIZE);
 #endif
 
@@ -74,36 +74,43 @@ auto receive_policy(int socket) -> std::optional<default_policy>
 
 // Possible cases:
 // 1. Key does not exist in cache or DB            (cache miss + DB miss) -> {monitor, ""}, is_valid = false
-// 2. Key is in cache, but validation fails        (cache hit, no DB lookup) -> {monitor, std::nullopt}, is_valid = false
-// 3. Key is in cache, validation succeeds         (cache hit, no DB lookup) -> {monitor, std::nullopt}, is_valid = true
-// 4. Key is not in cache, found in DB, invalid    (cache miss + DB hit) -> {monitor, res}, is_valid = false
-// 5. Key is not in cache, found in DB, valid      (cache miss + DB hit) -> {monitor, res}, is_valid = true
+// 2. Key is in cache, but validation fails        (cache hit, no DB lookup) -> {monitor, cached_metadata}, is_valid = false
+// 3. Key is in cache, validation succeeds         (cache hit, no DB lookup) -> {monitor, cached_metadata}, is_valid = true
+// 4. Key is not in cache, found in DB, invalid    (cache miss + DB hit) -> {monitor, complete_value}, is_valid = false
+// 5. Key is not in cache, found in DB, valid      (cache miss + DB hit) -> {monitor, complete_value}, is_valid = true
 auto filter_and_monitor(const std::unique_ptr<kv_client>& client,
   const query& query_args,
   const default_policy& def_policy,
-  bool& is_valid)
+  bool& is_valid,
+  bool& cache_hit)
   -> std::tuple<gdpr_monitor, std::optional<std::string>>
 {
   #ifdef METADATA_CACHE
-  // Try to get metadata from cache
+  // Check if the key is in the cache
+  std::optional<std::string> metadata_or_value;
   auto cached_metadata = cache.cache_get(query_args.key());
   if (cached_metadata) {
-    gdpr_filter filter(*cached_metadata);
-    is_valid = filter.validate(query_args, def_policy);
-    auto monitor = gdpr_monitor(filter, query_args, def_policy);
-    return {monitor, std::nullopt};  // Cache hit, no DB data returned
+    metadata_or_value = std::make_optional(*cached_metadata);
+    cache_hit = true;
   }
+  else {
+    // Cache miss - fetch from DB
+    metadata_or_value = client->gdpr_get(query_args.key());
+  }
+  #else
+  // No cache - always fetch from DB
+  auto metadata_or_value = client->gdpr_get(query_args.key());
   #endif
 
-  // Fetch data from client if not in cache
-  auto res = client->gdpr_get(query_args.key());
-  gdpr_filter filter(res);
+  // Create filter and monitor objects and validate the query
+  gdpr_filter filter(metadata_or_value);
   is_valid = filter.validate(query_args, def_policy);
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
-  return {monitor, std::move(res)};
+  return {std::move(monitor), std::move(metadata_or_value)};
 }
 
-auto handle_get(const std::unique_ptr<kv_client>& client,
+/* Get the value associated with a key */
+inline auto handle_get(const std::unique_ptr<kv_client>& client,
                 const query& query_args,
                 const default_policy& def_policy) -> std::string
 {
@@ -126,69 +133,65 @@ auto handle_get(const std::unique_ptr<kv_client>& client,
   return GET_FAILED;
 }
 
-auto handle_put(const std::unique_ptr<kv_client>& client,
+/* Insert a KV pair or update an existing value -- GDPR metadata is preserved */
+inline auto handle_put(const std::unique_ptr<kv_client>& client,
                 const query& query_args,
                 const default_policy& def_policy) -> std::string
 {
-  bool query_is_valid;
-  auto [monitor, res] = filter_and_monitor(client, query_args, def_policy, query_is_valid);
-  
-  if (!res) {
-    // Handle new key insertion
-    query_rewriter rewriter(query_args, def_policy, query_args.value());
-    std::string new_value = std::move(rewriter).new_value();
+  bool query_is_valid = false;
+  bool cache_hit = false;
+  auto [monitor, metadata_or_value] = filter_and_monitor(client, query_args, def_policy, query_is_valid, cache_hit);
 
-    // monitor.monitor_query(query_is_valid, new_value);
-    auto ret_val = client->gdpr_put(query_args.key(), new_value);
-   
-    #ifdef DEBUG
-    std::cout << "Put query: " << query_args.key() << " with value: " << hex_dump(new_value) << std::endl;
-    #endif
-
-    if (ret_val) {
-      #ifdef METADATA_CACHE
-      // Extract and cache metadata - move to avoid copy
-      std::string metadata = controller::preserve_only_gdpr_metadata(std::move(new_value));
-      #ifdef DEBUG
-      std::cout << "Caching metadata for key: " << query_args.key() << " in the following format:" << hex_dump(metadata) << std::endl;
-      #endif
-      cache.cache_put(query_args.key(), std::move(metadata));
-      #endif
-      return PUT_SUCCESS;
-    }
-  } else if (query_is_valid) {
-    // Handle existing key update
-    query_rewriter rewriter(res.value(), query_args.value());
-    std::string new_value = std::move(rewriter).new_value();
-    
-    monitor.monitor_query(query_is_valid, new_value);
-    auto ret_val = client->gdpr_put(query_args.key(), new_value);
-
-    if (ret_val) {
-      #ifdef METADATA_CACHE
-      // Update cache with new metadata - move to avoid copy
-      std::string metadata = controller::preserve_only_gdpr_metadata(std::move(new_value));
-      #ifdef DEBUG
-      std::cout << "Caching metadata for key: " << query_args.key() << " in the following format:" << hex_dump(metadata) << std::endl;
-      #endif
-      cache.cache_put(query_args.key(), std::move(metadata));
-      #endif
-      return PUT_SUCCESS;
-    }
-  } else {
-    // Log invalid operation (if needed)
+  // Early exit for invalid operations
+  if (!query_is_valid) {
     monitor.monitor_query(query_is_valid);
+    return PUT_FAILED;
+  }
+
+  // Construct new value
+  std::string new_value;
+  if (!metadata_or_value) {
+    // New key insertion
+    query_rewriter rewriter(query_args, def_policy, query_args.value());
+    new_value = std::move(rewriter).new_value();
+  } else {
+    // Update existing key (works for both cache hit and DB hit as it needs only the metadata)
+    query_rewriter rewriter(metadata_or_value.value(), query_args.value());
+    new_value = std::move(rewriter).new_value();
+  }
+
+  // Monitor and execute the put operation
+  monitor.monitor_query(query_is_valid, new_value);
+  #ifdef DEBUG
+  std::cout << "Put query: " << query_args.key() << " with value: " << hex_dump(new_value) << std::endl;
+  #endif
+  auto ret_val = client->gdpr_put(query_args.key(), new_value);
+  
+  if (ret_val) {
+    #ifdef METADATA_CACHE
+    // Only update cache if it wasn't a cache hit
+    if (!cache_hit) {
+      std::string metadata = controller::preserve_only_gdpr_metadata(std::move(new_value));
+      #ifdef DEBUG
+      std::cout << "Caching metadata for key: " << query_args.key() << " in format:" << hex_dump(metadata) << std::endl;
+      #endif
+      cache.cache_put(query_args.key(), std::move(metadata));
+    }
+    #endif
+    return PUT_SUCCESS;
   }
 
   return PUT_FAILED;
 }
 
-auto handle_delete(const std::unique_ptr<kv_client>& client,
+/* Delete a KV pair */
+inline auto handle_delete(const std::unique_ptr<kv_client>& client,
                   const query& query_args,
                   const default_policy& def_policy) -> std::string
 {
-  bool query_is_valid;
-  auto [monitor, res] = filter_and_monitor(client, query_args, def_policy, query_is_valid);
+  bool query_is_valid = false;
+  bool cache_hit = false;
+  auto [monitor, metadata_or_value] = filter_and_monitor(client, query_args, def_policy, query_is_valid, cache_hit);
 
   // Log the operation (if needed)
   monitor.monitor_query(query_is_valid);
@@ -207,7 +210,7 @@ auto handle_delete(const std::unique_ptr<kv_client>& client,
   return DELETE_FAILED;
 }
 
-auto handle_get_metadata(const std::unique_ptr<kv_client> &client,
+inline auto handle_get_metadata(const std::unique_ptr<kv_client> &client,
                 const query &query_args,
                 const default_policy &def_policy) -> std::string
 {
@@ -228,7 +231,7 @@ auto handle_get_metadata(const std::unique_ptr<kv_client> &client,
   return GETM_FAILED; // GETM_FAILED: Invalid key or does not comply with GDPR rules
 }
 
-auto handle_put_metadata(const std::unique_ptr<kv_client> &client,
+inline auto handle_put_metadata(const std::unique_ptr<kv_client> &client,
                 const query &query_args,
                 const default_policy &def_policy) -> std::string
 {
@@ -247,7 +250,7 @@ auto handle_put_metadata(const std::unique_ptr<kv_client> &client,
     // gpdr metadata of the value -- only putm operations can
     auto monitor = gdpr_monitor(filter, query_args, def_policy);
     // update the current value with the new one without modifying any metadata
-    query_rewriter rewriter(res.value(), query_args);
+    query_rewriter rewriter(query_args, res.value(), std::nullopt);
     std::string new_value = std::move(rewriter).new_value();
 
     // Perform the logging of the valid operation -- if needed
@@ -264,6 +267,55 @@ auto handle_put_metadata(const std::unique_ptr<kv_client> &client,
   monitor.monitor_query(is_valid);
 
   return PUTM_FAILED; // PUTM_FAILED: Invalid key or does not comply with GDPR rules
+}
+
+/* Insert a KV pair or update an existing value -- GDPR metadata can be altered */
+inline auto handle_put_combined(const std::unique_ptr<kv_client>& client,
+                const query& query_args,
+                const default_policy& def_policy) -> std::string
+{
+  bool query_is_valid = false;
+  bool cache_hit = false;
+  auto [monitor, metadata_or_value] = filter_and_monitor(client, query_args, def_policy, query_is_valid, cache_hit);
+
+  // Early exit for invalid operations
+  if (!query_is_valid) {
+    monitor.monitor_query(query_is_valid);
+    return PUTC_FAILED;
+  }
+
+  // Construct new value with the new/updated metadata
+  std::string new_value;
+  if (!metadata_or_value) {
+    // New key insertion
+    query_rewriter rewriter(query_args, def_policy, query_args.value());
+    new_value = std::move(rewriter).new_value();
+  } else {
+    // Update the metadata of an existing key
+    query_rewriter rewriter(query_args, metadata_or_value.value(), query_args.value());
+    new_value = std::move(rewriter).new_value();
+  }
+
+  // Monitor and execute the put operation
+  monitor.monitor_query(query_is_valid, new_value);
+  #ifdef DEBUG
+  std::cout << "Put query: " << query_args.key() << " with value: " << hex_dump(new_value) << std::endl;
+  #endif
+  auto ret_val = client->gdpr_put(query_args.key(), new_value);
+  
+  if (ret_val) {
+    #ifdef METADATA_CACHE
+    // Update cache
+    std::string metadata = controller::preserve_only_gdpr_metadata(std::move(new_value));
+    #ifdef DEBUG
+    std::cout << "Caching metadata for key: " << query_args.key() << " in format:" << hex_dump(metadata) << std::endl;
+    #endif
+    cache.cache_put(query_args.key(), std::move(metadata));
+    #endif
+    return PUTC_SUCCESS;
+  }
+
+  return PUTC_FAILED;
 }
 
 auto handle_get_logs(const query &query_args,
@@ -380,6 +432,9 @@ auto handle_connection
       }
       else if (query_args.cmd() == "getm") { /* ignore for now */
         response = handle_get_metadata(client, query_args, def_policy);
+      }
+      else if (query_args.cmd() == "putc") {
+        response = handle_put_combined(client, query_args, def_policy);
       }
       else if (query_args.cmd() == "getlogs") {
         // current client resembles the regulator

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -88,8 +88,8 @@ auto filter_and_monitor(const std::unique_ptr<kv_client>& client,
   // Try to get metadata from cache
   auto cached_metadata = cache.cache_get(query_args.key());
   if (cached_metadata) {
-    auto filter = std::make_shared<gdpr_filter>(*cached_metadata);
-    is_valid = filter->validate(query_args, def_policy);
+    gdpr_filter filter(*cached_metadata);
+    is_valid = filter.validate(query_args, def_policy);
     auto monitor = gdpr_monitor(filter, query_args, def_policy);
     return {monitor, std::nullopt};  // Cache hit, no DB data returned
   }
@@ -97,8 +97,8 @@ auto filter_and_monitor(const std::unique_ptr<kv_client>& client,
 
   // Fetch data from client if not in cache
   auto res = client->gdpr_get(query_args.key());
-  auto filter = std::make_shared<gdpr_filter>(res);
-  is_valid = filter->validate(query_args, def_policy);
+  gdpr_filter filter(res);
+  is_valid = filter.validate(query_args, def_policy);
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
   return {monitor, std::move(res)};
 }
@@ -109,8 +109,8 @@ auto handle_get(const std::unique_ptr<kv_client>& client,
 {
   // Always fetch from database as even in cache hit, we need to fetch the value
   auto res = client->gdpr_get(query_args.key());
-  auto filter = std::make_shared<gdpr_filter>(res);
-  bool is_valid = filter->validate(query_args, def_policy);
+  gdpr_filter filter(res);
+  bool is_valid = filter.validate(query_args, def_policy);
 
   // Create monitor and log
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
@@ -212,11 +212,11 @@ auto handle_get_metadata(const std::unique_ptr<kv_client> &client,
                 const default_policy &def_policy) -> std::string
 {
   auto res = client->gdpr_getm(query_args.key());
-  auto filter = std::make_shared<gdpr_filter>(res);
+  gdpr_filter filter(res);
 
   // Check if the retrieved key requires logging
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
-  bool is_valid = filter->validate(query_args, def_policy);
+  bool is_valid = filter.validate(query_args, def_policy);
   // Perform the logging of the (in)valid operation -- if needed
   monitor.monitor_query(is_valid);
   if (is_valid) {
@@ -240,8 +240,8 @@ auto handle_put_metadata(const std::unique_ptr<kv_client> &client,
     return "PUTM_FAILED: The specified key does not exist";
   }
   // if the key exists and complies with the gdpr rules, perform the GDPR metadata update
-  auto filter = std::make_shared<gdpr_filter>(res);
-  if ((is_valid = filter->validate(query_args, def_policy))) {
+  gdpr_filter filter(res);
+  if ((is_valid = filter.validate(query_args, def_policy))) {
     // Check if the retrieved value requires logging
     // the query args do not need to be checked since they cannot update the
     // gpdr metadata of the value -- only putm operations can

--- a/controller/source/controller.cpp
+++ b/controller/source/controller.cpp
@@ -100,24 +100,7 @@ auto filter_and_monitor(const std::unique_ptr<kv_client>& client,
   auto filter = std::make_shared<gdpr_filter>(res);
   is_valid = filter->validate(query_args, def_policy);
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
-  return {monitor, res};
-  
-}
-
-// Helper function to update cache with new metadata
-auto update_cache(std::string_view key, const std::string& value)
-{
-  #ifdef METADATA_CACHE
-  cache.cache_put(key, controller::preserve_only_gdpr_metadata(value));
-  #endif
-}
-
-// Helper function to remove a key from the cache
-auto remove_from_cache(std::string_view key)
-{
-  #ifdef METADATA_CACHE
-  cache.cache_remove(key);
-  #endif
+  return {monitor, std::move(res)};
 }
 
 auto handle_get(const std::unique_ptr<kv_client>& client,
@@ -128,12 +111,15 @@ auto handle_get(const std::unique_ptr<kv_client>& client,
   auto res = client->gdpr_get(query_args.key());
   auto filter = std::make_shared<gdpr_filter>(res);
   bool is_valid = filter->validate(query_args, def_policy);
-  
+
   // Create monitor and log
   auto monitor = gdpr_monitor(filter, query_args, def_policy);
   monitor.monitor_query(is_valid);
 
   if (is_valid && res) {
+    #ifdef DEBUG
+    std::cout << "Get query: " << query_args.key() << " with value: " << hex_dump(res.value()) << std::endl;
+    #endif
     return controller::remove_gdpr_metadata(std::move(res.value()));
   }
 
@@ -150,13 +136,22 @@ auto handle_put(const std::unique_ptr<kv_client>& client,
   if (!res) {
     // Handle new key insertion
     query_rewriter rewriter(query_args, def_policy, query_args.value());
-    monitor.monitor_query(query_is_valid, rewriter.new_value());
-    auto ret_val = client->gdpr_put(query_args.key(), rewriter.new_value());
+    std::string new_value = std::move(rewriter).new_value();
+
+    // monitor.monitor_query(query_is_valid, new_value);
+    auto ret_val = client->gdpr_put(query_args.key(), new_value);
+   
+    #ifdef DEBUG
+    std::cout << "Put query: " << query_args.key() << " with value: " << hex_dump(new_value) << std::endl;
+    #endif
 
     if (ret_val) {
       #ifdef METADATA_CACHE
       // Extract and cache metadata - move to avoid copy
-      std::string metadata = controller::preserve_only_gdpr_metadata(rewriter.new_value());
+      std::string metadata = controller::preserve_only_gdpr_metadata(std::move(new_value));
+      #ifdef DEBUG
+      std::cout << "Caching metadata for key: " << query_args.key() << " in the following format:" << hex_dump(metadata) << std::endl;
+      #endif
       cache.cache_put(query_args.key(), std::move(metadata));
       #endif
       return PUT_SUCCESS;
@@ -164,13 +159,18 @@ auto handle_put(const std::unique_ptr<kv_client>& client,
   } else if (query_is_valid) {
     // Handle existing key update
     query_rewriter rewriter(res.value(), query_args.value());
-    monitor.monitor_query(query_is_valid, rewriter.new_value());
-    auto ret_val = client->gdpr_put(query_args.key(), rewriter.new_value());
+    std::string new_value = std::move(rewriter).new_value();
+    
+    monitor.monitor_query(query_is_valid, new_value);
+    auto ret_val = client->gdpr_put(query_args.key(), new_value);
 
     if (ret_val) {
       #ifdef METADATA_CACHE
       // Update cache with new metadata - move to avoid copy
-      std::string metadata = controller::preserve_only_gdpr_metadata(rewriter.new_value());
+      std::string metadata = controller::preserve_only_gdpr_metadata(std::move(new_value));
+      #ifdef DEBUG
+      std::cout << "Caching metadata for key: " << query_args.key() << " in the following format:" << hex_dump(metadata) << std::endl;
+      #endif
       cache.cache_put(query_args.key(), std::move(metadata));
       #endif
       return PUT_SUCCESS;
@@ -248,9 +248,11 @@ auto handle_put_metadata(const std::unique_ptr<kv_client> &client,
     auto monitor = gdpr_monitor(filter, query_args, def_policy);
     // update the current value with the new one without modifying any metadata
     query_rewriter rewriter(res.value(), query_args);
+    std::string new_value = std::move(rewriter).new_value();
+
     // Perform the logging of the valid operation -- if needed
-    monitor.monitor_query(is_valid, rewriter.new_value());
-    auto ret_val = client->gdpr_putm(query_args.key(), rewriter.new_value());
+    monitor.monitor_query(is_valid, new_value);
+    auto ret_val = client->gdpr_putm(query_args.key(), new_value);
     if (ret_val) {
       return PUTM_SUCCESS;
     }

--- a/controller/source/default_policy.cpp
+++ b/controller/source/default_policy.cpp
@@ -115,7 +115,7 @@ auto default_policy::objection_string() const -> std::string {
 }
 
 auto default_policy::origin_string() const -> std::string {
-  return get_field_string<num_origins, org>(const_cast<std::bitset<num_origins>&>(this->m_origin), "origin");
+  return get_field_string<num_origins, org>(const_cast<std::bitset<num_origins>&>(this->m_origin), "src");
 }
 
 auto default_policy::share_string() const -> std::string {

--- a/controller/source/default_policy.cpp
+++ b/controller/source/default_policy.cpp
@@ -5,7 +5,10 @@ namespace controller {
 default_policy::default_policy()
     : m_encryption{false},
       m_purpose{0},
+      m_user_key{0},
       m_objection{0},
+      m_origin{0},
+      m_share{0},
       m_expiration{0},
       m_monitor{false}
 {
@@ -14,7 +17,10 @@ default_policy::default_policy()
 default_policy::default_policy(const std::string &input)
     : m_encryption{false},
       m_purpose{0},
+      m_user_key{0},
       m_objection{0},
+      m_origin{0},
+      m_share{0},
       m_expiration{0},
       m_monitor{false}
 {
@@ -29,14 +35,14 @@ default_policy::default_policy(const std::string &input)
     }
   }
   check_policy(option_map);
-  this->m_user_key = option_map["-sessionKey"];
-  this->m_origin = option_map["-origin"];
-  this->m_share = option_map["-objShare"];
+  set_bitmap<num_users, usr>(this->m_user_key, split_comma_string(std::string_view(option_map["-sessionKey"])));
+  set_bitmap<num_origins, org>(this->m_origin, split_comma_string(std::string_view(option_map["-origin"])));
+  set_bitmap<num_users, shr>(this->m_share, split_comma_string(std::string_view(option_map["-objShare"])));
+  set_bitmap<num_purposes, pur>(this->m_purpose, split_comma_string(std::string_view(option_map["-purpose"])));
+  set_bitmap<num_purposes, obj>(this->m_objection, split_comma_string(std::string_view(option_map["-objection"])));
   this->m_expiration = stoll(option_map["-expTime"]);
   this->m_encryption = str_to_bool(std::string_view(option_map["-encryption"]));
   this->m_monitor = str_to_bool(std::string_view(option_map["-monitor"]));
-  set_bitmap(this->m_purpose, split_comma_string(std::string_view(option_map["-purpose"])));
-  set_bitmap(this->m_objection, split_comma_string(std::string_view(option_map["-objection"])));
 }
 
 // default_policy::~default_policy()
@@ -55,9 +61,9 @@ auto default_policy::check_policy(const std::unordered_map<std::string, std::str
   }
 }
 
-auto default_policy::user_key() const -> std::string_view
+auto default_policy::user_key() const -> std::bitset<num_users>
 {
-  return std::string_view(this->m_user_key);
+  return this->m_user_key;
 }
 
 auto default_policy::encryption() const -> bool
@@ -75,9 +81,9 @@ auto default_policy::objection() const -> std::bitset<num_purposes>
   return this->m_objection;
 }
 
-auto default_policy::origin() const -> std::string_view
+auto default_policy::origin() const -> std::bitset<num_origins>
 {
-  return std::string_view(this->m_origin);
+  return this->m_origin;
 }
 
 auto default_policy::expiration() const -> int64_t
@@ -85,9 +91,9 @@ auto default_policy::expiration() const -> int64_t
   return this->m_expiration;
 }
 
-auto default_policy::share() const -> std::string_view
+auto default_policy::share() const -> std::bitset<num_users>
 {
-  return std::string_view(this->m_share);
+  return this->m_share;
 }
 
 auto default_policy::monitor() const -> bool
@@ -95,5 +101,25 @@ auto default_policy::monitor() const -> bool
   return this->m_monitor;
 }
 
+// Helper functions to get string representations of the fields
+auto default_policy::purpose_string() const -> std::string {
+  return get_field_string<num_purposes, pur>(const_cast<std::bitset<num_purposes>&>(this->m_purpose), "purpose");
+}
+
+auto default_policy::user_string() const -> std::string {
+  return get_field_string<num_users, usr>(const_cast<std::bitset<num_users>&>(this->m_user_key), "user");
+}
+
+auto default_policy::objection_string() const -> std::string {
+  return get_field_string<num_purposes, obj>(const_cast<std::bitset<num_purposes>&>(this->m_objection), "purpose");
+}
+
+auto default_policy::origin_string() const -> std::string {
+  return get_field_string<num_origins, org>(const_cast<std::bitset<num_origins>&>(this->m_origin), "origin");
+}
+
+auto default_policy::share_string() const -> std::string {
+  return get_field_string<num_users, shr>(const_cast<std::bitset<num_users>&>(this->m_share), "user");
+}
 
 } // namespace controller

--- a/controller/source/default_policy.hpp
+++ b/controller/source/default_policy.hpp
@@ -18,27 +18,34 @@ public:
   // ~default_policy();
 
   /* private members getters */
-  [[nodiscard]] auto user_key() const -> std::string_view;
+  [[nodiscard]] auto user_key() const -> std::bitset<num_users>;
   [[nodiscard]] auto encryption() const -> bool;
   [[nodiscard]] auto purpose() const -> std::bitset<num_purposes>;
   [[nodiscard]] auto objection() const -> std::bitset<num_purposes>;
-  [[nodiscard]] auto origin() const -> std::string_view;
+  [[nodiscard]] auto origin() const -> std::bitset<num_origins>;
   [[nodiscard]] auto expiration() const -> int64_t;
-  [[nodiscard]] auto share() const -> std::string_view;
+  [[nodiscard]] auto share() const -> std::bitset<num_users>;
   [[nodiscard]] auto monitor() const -> bool;
 
 private:
   // default policy fields
-  std::string m_user_key;
-  bool m_encryption;
+  std::bitset<num_users> m_user_key;
   std::bitset<num_purposes> m_purpose;
   std::bitset<num_purposes> m_objection;
-  std::string m_origin;
+  std::bitset<num_origins> m_origin;
+  std::bitset<num_users> m_share;
+  bool m_encryption;
   int64_t m_expiration;
-  std::string m_share;
   bool m_monitor;
 
   static auto check_policy(const std::unordered_map<std::string, std::string> &map) -> void;
+
+  // Helper functions to get string representations of the fields
+  auto purpose_string() const -> std::string;
+  auto user_string() const -> std::string;
+  auto objection_string() const -> std::string;
+  auto origin_string() const -> std::string;
+  auto share_string() const -> std::string;
 };
 
 } // namespace controller

--- a/controller/source/gdpr_filter.cpp
+++ b/controller/source/gdpr_filter.cpp
@@ -28,51 +28,15 @@ gdpr_filter::gdpr_filter(std::optional<std::string_view> ret_value)
       m_share{0},
       m_monitor{false}
 {
-  if (ret_value) {
-    m_valid = true;
-    std::string_view value = *ret_value;
-    size_t start = 0;
-    size_t end = 0;
-    int count = 0;
-
-    // retrieve the metadata fields without the actual value
-    while (count < metadata_prefix_fields && (end = value.find('|', start)) != std::string_view::npos) {
-      std::string_view token = value.substr(start, end - start);
-
-      switch (count) {
-        case usr: 
-          m_user_key = std::bitset<num_users>(std::stoull(std::string(token)));
-          break;
-        case encr:
-          m_encryption = (token == "1");
-          break;
-        case pur:
-          m_purpose = std::bitset<num_purposes>(std::stoull(std::string(token)));
-          break;
-        case obj:
-          m_objection = std::bitset<num_purposes>(std::stoull(std::string(token)));
-          break;
-        case org:
-          m_origin = std::bitset<num_origins>(std::stoull(std::string(token)));;
-          break;
-        case exp:
-          m_expiration = std::stoll(std::string(token));
-          break;
-        case shr:
-          m_share = std::bitset<num_users>(std::stoull(std::string(token)));;
-          break;
-        case log:
-          m_monitor = (token == "1");
-          break;
-        default:
-          break;
-      }
-      start = end + 1;
-      count++;
-    }
-
-    if (count != metadata_prefix_fields) {
-      throw std::invalid_argument("Invalid GDPR metadata format");
+  if (ret_value && !ret_value->empty()) {
+    try {
+      deserialize_binary_metadata(*ret_value);
+      m_valid = true;
+    } catch (const std::exception& e) {
+      #ifdef DEBUG
+      std::cout << "Failed to deserialize binary data: " << e.what() << std::endl;
+      #endif
+      m_valid = false;
     }
   }
 }
@@ -111,12 +75,6 @@ auto gdpr_filter::validate(const controller::query &query_args,
     #endif
     return false;
   }
-  // if (!validate_org(query_args.cond_origin(), def_policy.origin())) {
-  //   #ifdef DEBUG
-  //   std::cout << "query origin requirement different than the KV pair" << std::endl;
-  //   #endif
-  //   return false;
-  // }
   if (!validate_exp_time()) {
     // value expired
     // TODO: delete the value from the DB
@@ -138,14 +96,9 @@ auto gdpr_filter::validate(const controller::query &query_args,
 auto gdpr_filter::validate_session_key(const std::optional<std::bitset<num_users>> &query_user_key,
                                        const std::bitset<num_users> &def_user_key) const -> bool
 {
-  std::bitset<num_users> user_key = query_user_key.value_or(def_user_key);
+  const std::bitset<num_users>& user_key = query_user_key.has_value() ? query_user_key.value() : def_user_key;
   // Check if the user that requests the data is the owner (likely)
   // or if the data is shared with the client-user
-  #ifdef DEBUG
-  std::cout << "Validating user key: " << user_key.to_string() << " with " << 
-      this->user_key().to_string() << " and " << this->share().to_string() << 
-      " with result " << (user_key & (this->user_key() | this->share())).to_string() << std::endl;
-  #endif
   return ((user_key & (this->user_key() | this->share())) == user_key);
 }
 
@@ -175,19 +128,6 @@ auto gdpr_filter::validate_obj(const std::bitset<num_purposes> &query_pur,
   return ((this->objection() & def_pur) == 0);
 }
 
-// /* Validate that the requested query origin is the same with the KV pair */
-// auto gdpr_filter::validate_org(const std::bitset<num_origins> &query_org,
-//                                const std::bitset<num_origins> &def_org) const -> bool
-// {
-//   if (query_org.any()) {
-//     // the query origin override the defaults
-//     return (this->origin() & query_org) == query_org;
-//   }
-  
-//   // if no query origins are given, use the defaults of the client session
-//   return (this->origin() & def_org) == def_org;
-// }
-
 /* Validate that the KV pair is not expired */
 auto gdpr_filter::validate_exp_time() const -> bool
 {
@@ -212,7 +152,7 @@ auto gdpr_filter::is_valid() const -> bool
   return this->m_valid;
 }
 
-auto gdpr_filter::user_key() const -> std::bitset<num_users>
+auto gdpr_filter::user_key() const -> const std::bitset<num_users>&
 {
   return this->m_user_key;
 }
@@ -222,17 +162,17 @@ auto gdpr_filter::encryption() const -> bool
   return this->m_encryption;
 }
 
-auto gdpr_filter::purpose() const -> std::bitset<num_purposes>
+auto gdpr_filter::purpose() const -> const std::bitset<num_purposes>&
 {
   return this->m_purpose;
 }
 
-auto gdpr_filter::objection() const -> std::bitset<num_purposes>
+auto gdpr_filter::objection() const -> const std::bitset<num_purposes>&
 {
   return this->m_objection;
 }
 
-auto gdpr_filter::origin() const -> std::bitset<num_origins>
+auto gdpr_filter::origin() const -> const std::bitset<num_origins>&
 {
   return this->m_origin;
 }
@@ -242,7 +182,7 @@ auto gdpr_filter::expiration() const -> int64_t
   return this->m_expiration;
 }
 
-auto gdpr_filter::share() const -> std::bitset<num_users>
+auto gdpr_filter::share() const -> const std::bitset<num_users>&
 {
   return this->m_share;
 }
@@ -250,6 +190,39 @@ auto gdpr_filter::share() const -> std::bitset<num_users>
 auto gdpr_filter::monitor() const -> bool
 {
   return this->m_monitor;
+}
+
+auto gdpr_filter::deserialize_binary_metadata(std::string_view data) -> void {
+  if (data.size() < sizeof(metadata_header)) {
+    throw std::invalid_argument("Invalid binary data size - too small for header");
+  }
+
+  size_t offset = 0;
+  
+  // Read header
+  const metadata_header* header = reinterpret_cast<const metadata_header*>(data.data());
+  offset += sizeof(metadata_header);
+  
+  // Validate we have enough data
+  size_t expected_size = sizeof(metadata_header) + header->user_bytes + 
+                          header->purpose_bytes + header->purpose_bytes + 
+                          header->origin_bytes + header->user_bytes;
+
+  if (data.size() < expected_size) {
+    throw std::invalid_argument("Invalid binary data size - insufficient metadata");
+  }
+  
+  // Extract flags and expiration time
+  m_encryption = (header->flags & 1) != 0;
+  m_monitor = (header->flags & 2) != 0;
+  m_expiration = header->expiration_time;
+  
+  // Convert metadata to bitsets
+  m_user_key = convert_to_bitset<num_users>(data, offset, header->user_bytes);
+  m_purpose = convert_to_bitset<num_purposes>(data, offset, header->purpose_bytes);
+  m_objection = convert_to_bitset<num_purposes>(data, offset, header->purpose_bytes);
+  m_origin = convert_to_bitset<num_origins>(data, offset, header->origin_bytes);
+  m_share = convert_to_bitset<num_users>(data, offset, header->user_bytes);
 }
 
 } // namespace controller

--- a/controller/source/gdpr_filter.cpp
+++ b/controller/source/gdpr_filter.cpp
@@ -3,11 +3,29 @@
 
 namespace controller {
 
+gdpr_filter::gdpr_filter()
+    : m_valid{false},
+      m_encryption{false},
+      m_purpose{0},
+      m_user_key{0},
+      m_objection{0},
+      m_origin{0},
+      m_expiration{0},
+      m_share{0},
+      m_monitor{false}
+{
+}
+
 /* deserialize the metadata from the retrieved value and place them in the fields of the filter class */
 gdpr_filter::gdpr_filter(std::optional<std::string_view> ret_value)
     : m_valid{false},
       m_encryption{false},
+      m_purpose{0},
+      m_user_key{0},
+      m_objection{0},
+      m_origin{0},
       m_expiration{0},
+      m_share{0},
       m_monitor{false}
 {
   if (ret_value) {
@@ -23,7 +41,7 @@ gdpr_filter::gdpr_filter(std::optional<std::string_view> ret_value)
 
       switch (count) {
         case usr: 
-          m_user_key = token;
+          m_user_key = std::bitset<num_users>(std::stoull(std::string(token)));
           break;
         case encr:
           m_encryption = (token == "1");
@@ -35,13 +53,13 @@ gdpr_filter::gdpr_filter(std::optional<std::string_view> ret_value)
           m_objection = std::bitset<num_purposes>(std::stoull(std::string(token)));
           break;
         case org:
-          m_origin = token;
+          m_origin = std::bitset<num_origins>(std::stoull(std::string(token)));;
           break;
         case exp:
           m_expiration = std::stoll(std::string(token));
           break;
         case shr:
-          m_share = token;
+          m_share = std::bitset<num_users>(std::stoull(std::string(token)));;
           break;
         case log:
           m_monitor = (token == "1");
@@ -58,10 +76,6 @@ gdpr_filter::gdpr_filter(std::optional<std::string_view> ret_value)
     }
   }
 }
-
-// gdpr_filter::~gdpr_filter()
-// {
-// }
 
 /* Perform the validation checks for the gdpr metadata */
 auto gdpr_filter::validate(const controller::query &query_args, 
@@ -98,7 +112,6 @@ auto gdpr_filter::validate(const controller::query &query_args,
     return false;
   }
   // if (!validate_org(query_args.cond_origin(), def_policy.origin())) {
-  //   // query purposes are in the KV objection list 
   //   #ifdef DEBUG
   //   std::cout << "query origin requirement different than the KV pair" << std::endl;
   //   #endif
@@ -122,35 +135,19 @@ auto gdpr_filter::validate(const controller::query &query_args,
 }
 
 /* Validate that the user session key belongs to the owner or the share_with set */
-auto gdpr_filter::validate_session_key(std::optional<std::string_view> query_user_key,
-                                        std::string_view def_user_key) const -> bool
+auto gdpr_filter::validate_session_key(const std::optional<std::bitset<num_users>> &query_user_key,
+                                       const std::bitset<num_users> &def_user_key) const -> bool
 {
-  std::string_view user_key = query_user_key.value_or(def_user_key);
+  std::bitset<num_users> user_key = query_user_key.value_or(def_user_key);
   // Check if the user that requests the data is the owner (likely)
-  if (user_key == this->user_key()) {
-    return true;
-  }
-  
-  // If the user is not the owner, check if the data is shared with the client-user
-  // Check if share user string contains user_key as a sub-token separated by commas
-  std::string_view share = this->share();
-  size_t start = 0;
-  size_t end = 0;
-  while ((end = share.find(',', start)) != std::string_view::npos) {
-    if (user_key == share.substr(start, end - start)) {
-      return true;
-    }
-    start = end + 1;
-  }
-
-  // Check if the user key matches the last user in the shared users string
-  // if not, the function will return false
-  return (user_key == share.substr(start));
+  // or if the data is shared with the client-user
+  // return ((user_key == this->user_key()) ||  ((user_key & this->share()) != 0));
+  return ((user_key & (this->user_key() | this->share())) == user_key);
 }
 
 /* Validate that the purpose of the query is indeed in the allowed purposes */
 auto gdpr_filter::validate_pur(const std::bitset<num_purposes> &query_pur,
-                                const std::bitset<num_purposes> &def_pur) const -> bool
+                               const std::bitset<num_purposes> &def_pur) const -> bool
 {
   if (query_pur.any()) {
     // the query purposes override the defaults
@@ -163,7 +160,7 @@ auto gdpr_filter::validate_pur(const std::bitset<num_purposes> &query_pur,
 
 /* Validate that the purpose of the query is not in the obejction list */
 auto gdpr_filter::validate_obj(const std::bitset<num_purposes> &query_pur,
-                                const std::bitset<num_purposes> &def_pur) const -> bool
+                               const std::bitset<num_purposes> &def_pur) const -> bool
 {
   if (query_pur.any()) {
     // the query purposes override the defaults
@@ -175,12 +172,16 @@ auto gdpr_filter::validate_obj(const std::bitset<num_purposes> &query_pur,
 }
 
 // /* Validate that the requested query origin is the same with the KV pair */
-// auto gdpr_filter::validate_org(const std::string &query_org,
-//                                 const std::string &def_org) const -> bool
+// auto gdpr_filter::validate_org(const std::bitset<num_origins> &query_org,
+//                                const std::bitset<num_origins> &def_org) const -> bool
 // {
-//   std::string origin = query_org.empty() ? def_org : query_org;
-//   // Check if the origins match
-//   return (origin == this->origin());
+//   if (query_org.any()) {
+//     // the query origin override the defaults
+//     return (this->origin() & query_org) == query_org;
+//   }
+  
+//   // if no query origins are given, use the defaults of the client session
+//   return (this->origin() & def_org) == def_org;
 // }
 
 /* Validate that the KV pair is not expired */
@@ -191,8 +192,8 @@ auto gdpr_filter::validate_exp_time() const -> bool
     return true;
   }
   int64_t current_time = std::chrono::duration_cast<std::chrono::seconds>(
-                          std::chrono::system_clock::now().time_since_epoch()
-                          ).count();
+                         std::chrono::system_clock::now().time_since_epoch()
+                         ).count();
   return (current_time <= this->expiration());
 }
 
@@ -207,7 +208,7 @@ auto gdpr_filter::is_valid() const -> bool
   return this->m_valid;
 }
 
-auto gdpr_filter::user_key() const -> std::string_view
+auto gdpr_filter::user_key() const -> std::bitset<num_users>
 {
   return this->m_user_key;
 }
@@ -227,7 +228,7 @@ auto gdpr_filter::objection() const -> std::bitset<num_purposes>
   return this->m_objection;
 }
 
-auto gdpr_filter::origin() const -> std::string_view
+auto gdpr_filter::origin() const -> std::bitset<num_origins>
 {
   return this->m_origin;
 }
@@ -237,7 +238,7 @@ auto gdpr_filter::expiration() const -> int64_t
   return this->m_expiration;
 }
 
-auto gdpr_filter::share() const -> std::string_view
+auto gdpr_filter::share() const -> std::bitset<num_users>
 {
   return this->m_share;
 }

--- a/controller/source/gdpr_filter.cpp
+++ b/controller/source/gdpr_filter.cpp
@@ -141,7 +141,11 @@ auto gdpr_filter::validate_session_key(const std::optional<std::bitset<num_users
   std::bitset<num_users> user_key = query_user_key.value_or(def_user_key);
   // Check if the user that requests the data is the owner (likely)
   // or if the data is shared with the client-user
-  // return ((user_key == this->user_key()) ||  ((user_key & this->share()) != 0));
+  #ifdef DEBUG
+  std::cout << "Validating user key: " << user_key.to_string() << " with " << 
+      this->user_key().to_string() << " and " << this->share().to_string() << 
+      " with result " << (user_key & (this->user_key() | this->share())).to_string() << std::endl;
+  #endif
   return ((user_key & (this->user_key() | this->share())) == user_key);
 }
 

--- a/controller/source/gdpr_filter.cpp
+++ b/controller/source/gdpr_filter.cpp
@@ -4,7 +4,7 @@
 namespace controller {
 
 gdpr_filter::gdpr_filter()
-    : m_valid{false},
+    : m_valid{true},
       m_encryption{false},
       m_purpose{0},
       m_user_key{0},
@@ -18,7 +18,7 @@ gdpr_filter::gdpr_filter()
 
 /* deserialize the metadata from the retrieved value and place them in the fields of the filter class */
 gdpr_filter::gdpr_filter(std::optional<std::string_view> ret_value)
-    : m_valid{false},
+    : m_valid{true},
       m_encryption{false},
       m_purpose{0},
       m_user_key{0},

--- a/controller/source/gdpr_filter.hpp
+++ b/controller/source/gdpr_filter.hpp
@@ -20,11 +20,11 @@ public:
 
   [[nodiscard]] auto is_valid() const -> bool;
 
-  [[nodiscard]] auto user_key() const -> std::bitset<num_users>;
-  [[nodiscard]] auto purpose() const -> std::bitset<num_purposes>;
-  [[nodiscard]] auto objection() const -> std::bitset<num_purposes>;
-  [[nodiscard]] auto origin() const -> std::bitset<num_origins>;
-  [[nodiscard]] auto share() const -> std::bitset<num_users>;
+  [[nodiscard]] auto user_key() const -> const std::bitset<num_users>&;
+  [[nodiscard]] auto purpose() const -> const std::bitset<num_purposes>&;
+  [[nodiscard]] auto objection() const -> const std::bitset<num_purposes>&;
+  [[nodiscard]] auto origin() const -> const std::bitset<num_origins>&;
+  [[nodiscard]] auto share() const -> const std::bitset<num_users>&;
   [[nodiscard]] auto encryption() const -> bool;
   [[nodiscard]] auto expiration() const -> int64_t;
   [[nodiscard]] auto monitor() const -> bool;
@@ -59,6 +59,8 @@ private:
   bool m_encryption{false};
   int64_t m_expiration;
   bool m_monitor{false};
+
+  void deserialize_binary_metadata(std::string_view data);
 };
 
 } // namespace controller

--- a/controller/source/gdpr_filter.hpp
+++ b/controller/source/gdpr_filter.hpp
@@ -20,25 +20,27 @@ public:
 
   [[nodiscard]] auto is_valid() const -> bool;
 
-  [[nodiscard]] auto user_key() const -> std::string_view;
-  [[nodiscard]] auto encryption() const -> bool;
+  [[nodiscard]] auto user_key() const -> std::bitset<num_users>;
   [[nodiscard]] auto purpose() const -> std::bitset<num_purposes>;
   [[nodiscard]] auto objection() const -> std::bitset<num_purposes>;
-  [[nodiscard]] auto origin() const -> std::string_view;
+  [[nodiscard]] auto origin() const -> std::bitset<num_origins>;
+  [[nodiscard]] auto share() const -> std::bitset<num_users>;
+  [[nodiscard]] auto encryption() const -> bool;
   [[nodiscard]] auto expiration() const -> int64_t;
-  [[nodiscard]] auto share() const -> std::string_view;
   [[nodiscard]] auto monitor() const -> bool;
 
   [[nodiscard]] auto validate(const controller::query &query_args, 
                               const controller::default_policy &def_policy) const -> bool;
-  [[nodiscard]] auto validate_session_key(const std::optional<std::string_view> query_user_key,
-                                          std::string_view def_user_key) const -> bool;
+  [[nodiscard]] auto validate_session_key(const std::optional<std::bitset<num_users>> &query_user_key,
+                                          const std::bitset<num_users> &def_user_key) const -> bool;
+  // [[nodiscard]] auto validate_shr(const std::bitset<num_users> &query_shr,
+  //                                 const std::bitset<num_users> &def_shr) const -> bool;
+  // [[nodiscard]] auto validate_org(const std::bitset<num_origins> &query_org,
+  //                                 const std::bitset<num_origins> &def_org) const -> bool;
   [[nodiscard]] auto validate_pur(const std::bitset<num_purposes> &query_pur,
                                   const std::bitset<num_purposes> &def_pur) const -> bool;
   [[nodiscard]] auto validate_obj(const std::bitset<num_purposes> &query_pur,
                                   const std::bitset<num_purposes> &def_pur) const -> bool;
-  // [[nodiscard]] auto validate_org(const std::string &query_org,
-  //                                 const std::string &def_org) const -> bool;
   [[nodiscard]] auto validate_exp_time() const -> bool;
   [[nodiscard]] auto check_monitoring() const -> bool;
 
@@ -49,13 +51,13 @@ private:
   // metadata fields
   // Note on data types: it is okay to have std::string_view for the fields
   // as the result value that they are based on outlives the gdpr_filter object
-  std::string_view m_user_key{};
-  bool m_encryption{false};
+  std::bitset<num_users> m_user_key{};
   std::bitset<num_purposes> m_purpose;
   std::bitset<num_purposes> m_objection;
-  std::string_view m_origin{};
+  std::bitset<num_origins> m_origin{};
+  std::bitset<num_users> m_share{};
+  bool m_encryption{false};
   int64_t m_expiration;
-  std::string_view m_share{};
   bool m_monitor{false};
 };
 

--- a/controller/source/gdpr_metadata.hpp
+++ b/controller/source/gdpr_metadata.hpp
@@ -12,8 +12,9 @@
 
 namespace controller {
 
-constexpr int num_users = 64;
-constexpr int num_purposes = 64;
+constexpr int num_users = 128; // used for users and shared_with fields
+constexpr int num_purposes = 128; // used for purposes and objections
+constexpr int num_origins = 128; // used to map data origins sources
 constexpr int metadata_prefix_fields = 8;
 
 enum metadata_fields {
@@ -29,50 +30,84 @@ enum metadata_fields {
   max_gdpr_field_guard
 };
 
-// NOLINTBEGIN(cert-err58-cpp)
-static const std::unordered_map<std::string, std::size_t> pur_index = []() {
+// Generic template for creating index maps
+template<typename T>
+auto create_index_map(const std::string& prefix, std::size_t count) -> std::unordered_map<std::string, std::size_t> {
   std::unordered_map<std::string, std::size_t> temp;
-  for (std::size_t i = 0; i < num_purposes; i++) {
-    std::string value = "purpose" + std::to_string(i);
+  for (std::size_t i = 0; i < count; i++) {
+    std::string value = prefix + std::to_string(i);
     temp[value] = i;
   }
   return temp;
-}();
-// NOLINTEND(cert-err58-cpp)
+}
 
-/* return the mapping between purposes and indexes in bitmap*/
-auto inline get_pur() -> std::unordered_map<std::string, std::size_t>
-{
+// Create static maps for core metadata field types (usr/shr and pur/obj are correlated)
+// NOLINTBEGIN(cert-err58-cpp)
+static const std::unordered_map<std::string, std::size_t> pur_index = 
+  create_index_map<metadata_fields>("purpose", num_purposes);
+static const std::unordered_map<std::string, std::size_t> usr_index = 
+  create_index_map<metadata_fields>("user", num_users);
+static const std::unordered_map<std::string, std::size_t> org_index = 
+  create_index_map<metadata_fields>("origin", num_origins);
+
+// Generic getter functions
+template<metadata_fields Field>
+auto inline get_index_map() -> const std::unordered_map<std::string, std::size_t>&;
+
+template<>
+auto inline get_index_map<pur>() -> const std::unordered_map<std::string, std::size_t>& {
   return pur_index;
 }
 
+template<>
+auto inline get_index_map<obj>() -> const std::unordered_map<std::string, std::size_t>& {
+  return pur_index;
+}
+
+template<>
+auto inline get_index_map<usr>() -> const std::unordered_map<std::string, std::size_t>& {
+  return usr_index;
+}
+
+template<>
+auto inline get_index_map<shr>() -> const std::unordered_map<std::string, std::size_t>& {
+  return usr_index;
+}
+
+template<>
+auto inline get_index_map<org>() -> const std::unordered_map<std::string, std::size_t>& {
+  return org_index;
+}
+
+// Generic bitmap setter
 /* 
  *  takes as arguments a bitset and a vector of strings
- *  identifies the respective bit for each key based on the defined map of purposes
+ *  identifies the respective bit for each key based on the defined map of metadata fields
  *  and sets the appropriate bits
  */
-template<std::size_t N>
+template<std::size_t N, metadata_fields Field>
 auto inline set_bitmap(std::bitset<N> &bits, const std::vector<std::string> &bit_keys) -> void {
-  std::size_t index = 0;
+  const auto& index_map = get_index_map<Field>();
   for (const auto &bit_key : bit_keys) {
-    index = get_pur()[bit_key];
-    bits.set(index);
+    auto it = index_map.find(bit_key);
+    if (it != index_map.end()) {
+      bits.set(it->second);
+    }
   }
 }
 
+// Generic string generator
 /* 
  *  takes as arguments a bitset and
- *  identifies the respective set bits and, based on the defined map of purposes,
- *  returns a comma separated string with the appropriate set of purposes
+ *  identifies the respective set bits and, based on the defined map of metadata fields,
+ *  returns a comma separated string with the appropriate set of metadata fields
  */
-template<std::size_t N>
-auto inline get_purposes_string(std::bitset<N> &bits) -> std::string {
-  // Iterate over the bits and check each one
+template<std::size_t N, metadata_fields Field>
+auto inline get_field_string(const std::bitset<N> &bits, const std::string& prefix) -> std::string {
   std::stringstream res;
   for (size_t i = 0; i < bits.size(); i++) {
     if (bits.test(i)) {
-      // The i-th bit is set
-      res << "purpose" << i << ",";
+      res << prefix << i << ",";
     }
   }
   return res.str();

--- a/controller/source/gdpr_metadata.hpp
+++ b/controller/source/gdpr_metadata.hpp
@@ -17,6 +17,16 @@ constexpr int num_purposes = 128; // used for purposes and objections
 constexpr int num_origins = 128; // used to map data origins sources
 constexpr int metadata_prefix_fields = 8;
 
+// Header structure for storing the metadata
+struct alignas(8) metadata_header {
+  uint16_t user_bytes = num_users / sizeof(uint64_t);
+  uint16_t purpose_bytes = num_purposes / sizeof(uint64_t);
+  uint16_t origin_bytes = num_origins / sizeof(uint64_t);
+  uint8_t flags = 0;  // encryption (bit 0), monitor (bit 1)
+  uint8_t padding[1];  // Explicit padding
+  int64_t expiration_time = 0;  
+};
+
 enum metadata_fields {
   usr,
   encr,
@@ -171,14 +181,29 @@ auto inline get_expiration_time(int64_t secs_from_now) -> int64_t {
  * @param value The string containing the GDPR metadata and actual value.
  * @return The actual value after removing the metadata.
  */
-auto inline remove_gdpr_metadata(std::string value) -> std::string {
-  size_t last_delimiter_idx = value.find_last_of('|');
-  if (last_delimiter_idx != std::string::npos && last_delimiter_idx + 1 < value.length())
-  {
-    // Erase the metadata and return the actual value
-    value.erase(0, last_delimiter_idx + 1);
-  } 
-  return value;
+auto inline remove_gdpr_metadata(std::string&& value) -> std::string {
+  if (value.size() < sizeof(metadata_header)) {
+    return std::move(value);  // Not enough data for header, return as-is
+  }
+  
+  try {
+    // Read the header to determine metadata size
+    const metadata_header* header = reinterpret_cast<const metadata_header*>(value.data());
+    
+    // Calculate total metadata size
+    size_t metadata_size = sizeof(metadata_header) + header->user_bytes + 
+                            header->purpose_bytes + header->purpose_bytes + 
+                            header->origin_bytes + header->user_bytes;
+    
+    if (value.size() > metadata_size) {
+      // Erase the metadata and return the actual value
+      value.erase(0, metadata_size);
+    }
+  } catch (...) {
+    // If anything goes wrong, return original value
+    return std::move(value);
+  }  
+  return std::move(value);
 }
 
 /**
@@ -188,14 +213,69 @@ auto inline remove_gdpr_metadata(std::string value) -> std::string {
  * @param value The string containing the GDPR metadata and the value.
  * @return The GDPR metadata.
  */
-auto inline preserve_only_gdpr_metadata(std::string value) -> std::string {
-  size_t last_delimiter_idx = value.find_last_of('|');
-  if (last_delimiter_idx != std::string::npos && last_delimiter_idx + 1 < value.length())
-  {
-    // Erase the value and return only the GDPR metadata
-    value.erase(last_delimiter_idx + 1, value.length());
-  }  
-  return value;
+auto inline preserve_only_gdpr_metadata(std::string&& value) -> std::string {
+  if (value.size() < sizeof(metadata_header)) {
+    return std::move(value);  // Not enough data for header, return as-is
+  }
+  
+  try {
+    // Read the header to determine metadata size
+    const metadata_header* header = reinterpret_cast<const metadata_header*>(value.data());
+    
+    // Calculate total metadata size
+    size_t metadata_size = sizeof(metadata_header) + header->user_bytes + 
+                            header->purpose_bytes + header->purpose_bytes + 
+                            header->origin_bytes + header->user_bytes;
+    
+    if (value.size() > metadata_size) {
+      // Erase the value and return only the GDPR metadata
+      value.erase(metadata_size);
+    }
+  } catch (...) {
+    // If anything goes wrong, return original value
+    return std::move(value);
+  }
+  
+  return std::move(value);
+}
+
+// Optimized code for converting the binary data of a string to a bitset
+template<size_t N>
+std::bitset<N> convert_to_bitset(std::string_view data, size_t& offset, uint16_t num_bytes) {
+  static_assert((N & (N - 1)) == 0, "N must be power of 2");
+    
+  if (offset + num_bytes > data.size()) {
+    throw std::out_of_range("Offset exceeds data size");
+  }
+  
+  std::bitset<N> bits;
+  
+  // Loop over data in 8-byte chunks with direct casting
+  for (size_t i = 0; i < num_bytes; i += sizeof(uint64_t)) {
+    uint64_t word = 0;
+    size_t bytes_remaining = num_bytes - i;
+    
+    if (bytes_remaining >= sizeof(uint64_t)) {
+      // Direct cast for full 8-byte reads (now safe due to alignment)
+      word = *reinterpret_cast<const uint64_t*>(data.data() + offset + i);
+    } else {
+      // Handle partial reads at the end
+      std::memcpy(&word, data.data() + offset + i, bytes_remaining);
+    }
+    
+    // Create bitset from word
+    if (word != 0) {
+      size_t bit_offset = i * sizeof(uint64_t);
+      for (size_t bit = 0; bit < 64 && bit_offset + bit < N; ++bit) {
+          if (word & (1ULL << bit)) {
+              bits.set(bit_offset + bit);  // Direct bit setting
+          }
+      }
+    }
+  }
+  
+  offset += num_bytes;
+  return bits;  
 }
 
 } // namespace controller

--- a/controller/source/gdpr_metadata.hpp
+++ b/controller/source/gdpr_metadata.hpp
@@ -48,7 +48,7 @@ static const std::unordered_map<std::string, std::size_t> pur_index =
 static const std::unordered_map<std::string, std::size_t> usr_index = 
   create_index_map<metadata_fields>("user", num_users);
 static const std::unordered_map<std::string, std::size_t> org_index = 
-  create_index_map<metadata_fields>("origin", num_origins);
+  create_index_map<metadata_fields>("src", num_origins);
 
 // Generic getter functions
 template<metadata_fields Field>

--- a/controller/source/gdpr_regulator.cpp
+++ b/controller/source/gdpr_regulator.cpp
@@ -21,7 +21,7 @@ gdpr_regulator::gdpr_regulator()
 auto gdpr_regulator::validate_reg_key(const controller::query &query_args, 
                                       const controller::default_policy &def_policy) -> bool
 {
-  std::string_view user_key = query_args.user_key().value_or(def_policy.user_key());
+  std::string_view user_key = get_field_string<num_users, usr>(query_args.user_key().value_or(def_policy.user_key()), "user");
   return (user_key == regulator_key);
 }
 

--- a/controller/source/global_gdpr_metadata_cache.hpp
+++ b/controller/source/global_gdpr_metadata_cache.hpp
@@ -20,8 +20,18 @@ private:
       std::shared_ptr<const T> data;
     };
     
+    // Add heterogeneous lookup support
+    struct string_hash {
+      using hash_type = std::hash<std::string_view>;
+      using is_transparent = void;
+      
+      size_t operator()(const char* str) const { return hash_type{}(str); }
+      size_t operator()(std::string_view str) const { return hash_type{}(str); }
+      size_t operator()(const std::string& str) const { return hash_type{}(str); }
+    };
+
     struct Shard {
-      std::unordered_map<std::string, CacheEntry> entries;
+      std::unordered_map<std::string, CacheEntry, string_hash, std::equal_to<>> entries;
       std::shared_mutex mutex;  // Fine-grained per-shard locking
       std::atomic<size_t> size{0};
       mutable std::mt19937 rng{std::random_device{}()};  // For random eviction
@@ -56,7 +66,7 @@ public:
       auto& shard = shards[get_shard_index(key)];
       std::shared_lock<std::shared_mutex> lock(shard.mutex);
       
-      auto it = shard.entries.find(std::string(key));
+      auto it = shard.entries.find(key);
       if (it != shard.entries.end()) {
         #ifdef CACHE_STATS
         m_hits.fetch_add(1, std::memory_order_relaxed);
@@ -72,17 +82,16 @@ public:
     }
     
     // Put metadata - moves data to avoid copying
-    void cache_put(std::string_view key, T&& metadata) {
+    template<typename U>
+    void cache_put(std::string_view key, U&& metadata) {
 
       auto& shard = shards[get_shard_index(key)];
       std::unique_lock<std::shared_mutex> lock(shard.mutex);
       
-      std::string key_str(key);
-      auto it = shard.entries.find(key_str);
-      
+      auto it = shard.entries.find(key);
       if (it != shard.entries.end()) {
         // Update existing entry
-        it->second.data = std::make_shared<const T>(std::move(metadata));
+        it->second.data = std::make_shared<const T>(std::forward<U>(metadata));
       } else {
         // Add new entry, evict if necessary
         if (shard.size.load(std::memory_order_relaxed) >= max_size_per_shard) {
@@ -90,9 +99,9 @@ public:
         }
         
         CacheEntry entry;
-        entry.data = std::make_shared<const T>(std::move(metadata));
+        entry.data = std::make_shared<const T>(std::forward<U>(metadata));
         
-        shard.entries.emplace(std::move(key_str), std::move(entry));
+        shard.entries.emplace(std::string(key), std::move(entry));
         shard.size.fetch_add(1, std::memory_order_relaxed);
       }
     }
@@ -103,7 +112,7 @@ public:
         auto& shard = shards[get_shard_index(key)];
         std::unique_lock<std::shared_mutex> lock(shard.mutex);  // Exclusive lock
         
-        auto it = shard.entries.find(std::string(key));
+        auto it = shard.entries.find(key);
         if (it != shard.entries.end()) {
             shard.entries.erase(it);
             shard.size.fetch_sub(1, std::memory_order_relaxed);

--- a/controller/source/global_gdpr_metadata_cache.hpp
+++ b/controller/source/global_gdpr_metadata_cache.hpp
@@ -34,7 +34,7 @@ private:
       std::unordered_map<std::string, CacheEntry, string_hash, std::equal_to<>> entries;
       std::shared_mutex mutex;  // Fine-grained per-shard locking
       std::atomic<size_t> size{0};
-      mutable std::mt19937 rng{std::random_device{}()};  // For random eviction
+      mutable std::mt19937 rng{std::random_device{}()};
     };
     
     std::array<Shard, NUM_SHARDS> shards;
@@ -152,19 +152,18 @@ public:
     #endif
 
 private:
-    // O(1) random eviction - much faster than LFU
+    // random eviction
     void random_evict_from_shard(Shard& shard) {
-      
       if (shard.entries.empty()) return;
+
+      // Limit traversal to max 20 elements
+      const size_t max_advance = std::min(shard.entries.size(), size_t(20));
+      std::uniform_int_distribution<size_t> dist(0, max_advance - 1);
+      size_t advance_count = dist(shard.rng);
       
-      // Generate random index
-      std::uniform_int_distribution<size_t> dist(0, shard.entries.size() - 1);
-      size_t random_index = dist(shard.rng);
-      
-      // Find iterator at random position
       auto it = shard.entries.begin();
-      std::advance(it, random_index);
-      
+      std::advance(it, advance_count);  // Max 20 iterations
+
       shard.entries.erase(it);
       shard.size.fetch_sub(1, std::memory_order_relaxed);
     }

--- a/controller/source/logging/log_common.hpp
+++ b/controller/source/logging/log_common.hpp
@@ -112,27 +112,33 @@ inline auto gdpr_metadata_fmt(std::string_view value_str) -> std::string {
     std::string_view token = value_str.substr(start, end - start);
 
     switch (count) {
-      case usr: 
-        res.append("User/Owner: ").append(token).append(", ");
-        break;
+      case usr:
+        {
+          auto user_key = std::bitset<num_users>(std::stoull(std::string(token)));
+          res.append("User/Owner: ").append(get_field_string<num_users, usr>(user_key, "user")).append(", ");
+          break;
+        }
       case encr:
         res.append("Encryption enabled: ").append(token == "1" ? "true" : "false").append(", ");
         break;
       case pur:
         {
           auto purposes = std::bitset<num_purposes>(std::stoull(std::string(token)));
-          res.append("Purposes: ").append(get_purposes_string(purposes));
+          res.append("Purposes: ").append(get_field_string<num_purposes, pur>(purposes, "purpose")).append(", ");
           break;
         }
       case obj:
         {
           auto objections = std::bitset<num_purposes>(std::stoull(std::string(token)));
-          res.append("Objections: ").append(get_purposes_string(objections));
+          res.append("Objections: ").append(get_field_string<num_purposes, obj>(objections, "purpose")).append(", ");
           break;
         }
       case org:
-        res.append("Data origin: ").append(token).append(", ");
-        break;
+        {
+          auto origins = std::bitset<num_origins>(std::stoull(std::string(token)));
+          res.append("Data origin: ").append(get_field_string<num_origins, org>(origins, "origin")).append(", ");
+          break;
+        }
       case exp:
         {
           std::string_view expire_time = (token == "0") ?
@@ -141,8 +147,11 @@ inline auto gdpr_metadata_fmt(std::string_view value_str) -> std::string {
           break;
         }
       case shr:
-        res.append("Shared with: ").append(token).append(", ");
-        break;
+        {
+          auto shared_with = std::bitset<num_users>(std::stoull(std::string(token)));
+          res.append("Shared with: ").append(get_field_string<num_users, shr>(shared_with, "user")).append(", ");
+          break;
+        }
       case log:
         res.append("Log enabled: ").append(token == "1" ? "true" : "false").append(", ");
         break;

--- a/controller/source/logging/log_common.hpp
+++ b/controller/source/logging/log_common.hpp
@@ -136,7 +136,7 @@ inline auto gdpr_metadata_fmt(std::string_view value_str) -> std::string {
       case org:
         {
           auto origins = std::bitset<num_origins>(std::stoull(std::string(token)));
-          res.append("Data origin: ").append(get_field_string<num_origins, org>(origins, "origin")).append(", ");
+          res.append("Data origin: ").append(get_field_string<num_origins, org>(origins, "src")).append(", ");
           break;
         }
       case exp:

--- a/controller/source/logging/log_common.hpp
+++ b/controller/source/logging/log_common.hpp
@@ -25,7 +25,8 @@ enum operation : uint8_t {
   del = 3U,
   getm = 4U,
   putm = 5U,
-  get_logs = 6U
+  putc = 6U,
+  get_logs = 7U
 };
 
 /**
@@ -46,6 +47,9 @@ inline auto convert_operation_to_enum(std::string_view oper) -> operation {
   }
   if (oper == "putm") {
     return operation::putm;
+  }
+  if (oper == "putc") {
+    return operation::putc;
   }
   if (oper == "getLogs") {
     return operation::get_logs;
@@ -72,6 +76,9 @@ inline auto convert_enum_to_operation(const operation oper) -> std::string  {
   }
   if (oper == operation::putm) {
     return "putm";
+  }
+  if (oper == operation::putc) {
+    return "putc";
   }
   if (oper == operation::get_logs) {
     return "getLogs";

--- a/controller/source/logging/logger.hpp
+++ b/controller/source/logging/logger.hpp
@@ -58,7 +58,7 @@ public:
     // format is the following:
     // timestamp,user_key,operation,operation_result,new_value(if applicable)
     *log_file << std::chrono::system_clock::now().time_since_epoch().count() << ","
-              << query_args.user_key().value_or(def_policy.user_key()) << ","
+              << get_field_string<num_users, usr>(query_args.user_key().value_or(def_policy.user_key()), "user") << ","
               << convert_operation_to_enum(query_args.cmd()) << ","
               << result << ","
               << new_val << std::endl;
@@ -84,7 +84,7 @@ public:
     // Encode the timestamp as a fixed-width integer type
     const int64_t timestamp = std::chrono::system_clock::now().time_since_epoch().count();
     // Encode the user key as a string
-    std::string_view user_key = query_args.user_key().value_or(def_policy.user_key());
+    std::string_view user_key = get_field_string<num_users, usr>(query_args.user_key().value_or(def_policy.user_key()), "user");
     // Encode the operation type (3bits) and the operation result (1 bit) as a single byte
     const uint8_t operation = static_cast<uint8_t>((convert_operation_to_enum(query_args.cmd()) & operation_mask) << 1U);
     const uint8_t valid_bit = (valid ? 0x01U : 0x00U);

--- a/controller/source/logging/monitor.hpp
+++ b/controller/source/logging/monitor.hpp
@@ -16,9 +16,9 @@ public:
    * Generic constructor when a value is retrieved
    * Action: Check the current gdpr metadata
    */ 
-  gdpr_monitor(std::shared_ptr<gdpr_filter> filter, const query& query_args, const default_policy& def_policy): 
-    m_filter{std::move(filter)}, m_query_args{query_args}, m_def_policy{def_policy}, 
-    m_history_logger{logger::get_instance()}, m_monitor_needed{m_filter->check_monitoring()} 
+  gdpr_monitor(const gdpr_filter& filter, const query& query_args, const default_policy& def_policy): 
+    m_filter{filter}, m_query_args{query_args}, m_def_policy{def_policy}, 
+    m_history_logger{logger::get_instance()}, m_monitor_needed{m_filter.check_monitoring()} 
   {
   }
   /* 
@@ -27,7 +27,7 @@ public:
    * Action: Check the query args & then the default policy
    */ 
   gdpr_monitor(const query& query_args, const default_policy& def_policy): 
-    m_filter{nullptr}, m_query_args{query_args}, m_def_policy{def_policy}, 
+    m_filter{}, m_query_args{query_args}, m_def_policy{def_policy}, 
     m_history_logger{logger::get_instance()}
   {
     m_monitor_needed = m_query_args.monitor().value_or(m_def_policy.monitor());
@@ -38,13 +38,13 @@ public:
    * Action: It's current gdpr metadata except from the transition from false to true based on query args
    * callable as: gdpr_monitor(filter, query_args, def_policy, controller::gdpr_monitor::putm_monitor_t{});
    */ 
-  gdpr_monitor(std::shared_ptr<gdpr_filter> filter, const query& query_args,
+  gdpr_monitor(const gdpr_filter& filter, const query& query_args,
               const default_policy& def_policy, putm_monitor_t /*unused*/): 
-    m_filter{std::move(filter)}, m_query_args{query_args}, 
+    m_filter{filter}, m_query_args{query_args}, 
     m_def_policy{def_policy}, m_history_logger{logger::get_instance()} 
   {
-    m_monitor_needed = (!m_filter->check_monitoring() && m_query_args.monitor().value_or(false)) ?
-                        m_query_args.monitor().value() : m_filter->check_monitoring();      
+    m_monitor_needed = (!m_filter.check_monitoring() && m_query_args.monitor().value_or(false)) ?
+                        m_query_args.monitor().value() : m_filter.check_monitoring();      
   }
 
   void monitor_query(const bool& valid, std::string_view new_val = {}) {
@@ -54,7 +54,7 @@ public:
   }
 
 private:
-  std::shared_ptr<gdpr_filter> m_filter;
+  const gdpr_filter& m_filter;
 
   const query& m_query_args;
 

--- a/controller/source/query.cpp
+++ b/controller/source/query.cpp
@@ -5,7 +5,9 @@
 namespace controller {
 
 query::query()
-    : m_cond_purpose{0},
+    : m_cond_share{0},
+      m_cond_origin{0},
+      m_cond_purpose{0},
       m_cond_objection{0},
       m_cond_expiration{0},
       m_cond_monitor{false}
@@ -18,7 +20,9 @@ query::query(std::string_view user_key,
              std::string_view cmd)
     : m_cmd{cmd},
       m_key{key},
-      m_user_key{user_key},
+      m_user_key{0},
+      m_cond_share{0},
+      m_cond_origin{0},
       m_cond_purpose{0},
       m_cond_objection{0},
       m_cond_expiration{0},
@@ -27,7 +31,9 @@ query::query(std::string_view user_key,
 }
 
 query::query(std::string_view input)
-    : m_cond_purpose{0},
+    : m_cond_share{0},
+      m_cond_origin{0},
+      m_cond_purpose{0},
       m_cond_objection{0},
       m_cond_expiration{0},
       m_cond_monitor{false}
@@ -155,13 +161,16 @@ auto query::parse_query(std::string_view reg_query_args) -> void
 auto query::parse_option(std::string_view option, std::string_view value) -> void
 {
   if (option == "sessionKey") {
-    this->m_user_key = value;
+    this->m_user_key.emplace();
+    set_bitmap<num_users, usr>(this->m_user_key.value(), split_comma_string(value));
   } 
   else if (option == "objOrig") {
-    this->m_origin = value;
+    this->m_origin.emplace();
+    set_bitmap<num_origins, org>(this->m_origin.value(), split_comma_string(value));
   } 
   else if (option == "objShare") {
-    this->m_share = value;
+    this->m_share.emplace();
+    set_bitmap<num_users, shr>(this->m_share.value(), split_comma_string(value));
   } 
   else if (option == "objExp") {
     this->m_expiration = stoi(std::string(value));
@@ -169,29 +178,29 @@ auto query::parse_option(std::string_view option, std::string_view value) -> voi
   } 
   else if (option == "objPur") {
     this->m_purpose.emplace();
-    set_bitmap(this->m_purpose.value(), split_comma_string(value));
+    set_bitmap<num_purposes, pur>(this->m_purpose.value(), split_comma_string(value));
   } 
   else if (option == "objObjections") {
     this->m_objection.emplace();
-    set_bitmap(this->m_objection.value(), split_comma_string(value));
+    set_bitmap<num_purposes, obj>(this->m_objection.value(), split_comma_string(value));
   } 
   else if (option == "monitor") {
     this->m_monitor = str_to_bool(value);
   } 
   else if (option == "objOrigIs") {
-    this->m_cond_origin = value;
+    set_bitmap<num_origins, org>(this->m_cond_origin, split_comma_string(value));
   } 
   else if (option == "objShareIs") {
-    this->m_cond_share = value;
+    set_bitmap<num_users, shr>(this->m_cond_share, split_comma_string(value));
   } 
   else if (option == "objExpIs") {
     this->m_cond_expiration = stoi(std::string(value));
   } 
   else if (option == "objPurIs") {
-    set_bitmap(this->m_cond_purpose, split_comma_string(value));
+    set_bitmap<num_purposes, pur>(this->m_cond_purpose, split_comma_string(value));
   } 
   else if (option == "objObjectionsIs") {
-    set_bitmap(this->m_cond_objection, split_comma_string(value));
+    set_bitmap<num_purposes, obj>(this->m_cond_objection, split_comma_string(value));
   } 
   else if (option == "monitorIs") {
     this->m_cond_monitor = str_to_bool(value);
@@ -227,9 +236,9 @@ auto query::value() const -> std::string_view
   return this->m_value;
 }
 
-auto query::user_key() const -> std::optional<std::string_view>
+auto query::user_key() const -> std::optional<std::bitset<num_users>>
 {
-  return this->m_user_key ? std::optional<std::string_view>(*this->m_user_key) : std::nullopt;
+  return this->m_user_key;
 }
 
 auto query::purpose() const -> std::optional<std::bitset<num_purposes>>
@@ -242,9 +251,9 @@ auto query::objection() const -> std::optional<std::bitset<num_purposes>>
   return this->m_objection;
 }
 
-auto query::origin() const -> std::optional<std::string_view>
+auto query::origin() const -> std::optional<std::bitset<num_origins>>
 {
-  return this->m_origin ? std::optional<std::string_view>(*this->m_origin) : std::nullopt;
+  return this->m_origin;
 }
 
 auto query::expiration() const -> std::optional<int64_t>
@@ -252,9 +261,9 @@ auto query::expiration() const -> std::optional<int64_t>
   return this->m_expiration;
 }
 
-auto query::share() const -> std::optional<std::string_view>
+auto query::share() const -> std::optional<std::bitset<num_users>>
 {
-  return this->m_share ? std::optional<std::string_view>(*this->m_share) : std::nullopt;
+  return this->m_share;
 }
 
 auto query::monitor() const -> std::optional<bool>
@@ -272,7 +281,7 @@ auto query::cond_objection() const -> std::bitset<num_purposes>
   return this->m_cond_objection;
 }
 
-auto query::cond_origin() const -> std::string_view
+auto query::cond_origin() const -> std::bitset<num_origins>
 {
   return this->m_cond_origin;
 }
@@ -282,7 +291,7 @@ auto query::cond_expiration() const -> int64_t
   return this->m_cond_expiration;
 }
 
-auto query::cond_share() const -> std::string_view
+auto query::cond_share() const -> std::bitset<num_users>
 {
   return this->m_cond_share;
 }

--- a/controller/source/query.cpp
+++ b/controller/source/query.cpp
@@ -221,7 +221,7 @@ auto query::print() -> void
   std::cout << this->m_cmd << " " << this->m_key << " " << this->m_value << "\n";
 }
 
-auto query::cmd() const -> std::string
+auto query::cmd() const -> const std::string&
 {
   return this->m_cmd;
 }
@@ -236,22 +236,22 @@ auto query::value() const -> std::string_view
   return this->m_value;
 }
 
-auto query::user_key() const -> std::optional<std::bitset<num_users>>
+auto query::user_key() const -> const std::optional<std::bitset<num_users>>&
 {
   return this->m_user_key;
 }
 
-auto query::purpose() const -> std::optional<std::bitset<num_purposes>>
+auto query::purpose() const -> const std::optional<std::bitset<num_purposes>>&
 {
   return this->m_purpose;
 }
 
-auto query::objection() const -> std::optional<std::bitset<num_purposes>>
+auto query::objection() const -> const std::optional<std::bitset<num_purposes>>&
 {
   return this->m_objection;
 }
 
-auto query::origin() const -> std::optional<std::bitset<num_origins>>
+auto query::origin() const -> const std::optional<std::bitset<num_origins>>&
 {
   return this->m_origin;
 }
@@ -261,7 +261,7 @@ auto query::expiration() const -> std::optional<int64_t>
   return this->m_expiration;
 }
 
-auto query::share() const -> std::optional<std::bitset<num_users>>
+auto query::share() const -> const std::optional<std::bitset<num_users>>&
 {
   return this->m_share;
 }
@@ -271,17 +271,17 @@ auto query::monitor() const -> std::optional<bool>
   return this->m_monitor;
 }
 
-auto query::cond_purpose() const -> std::bitset<num_purposes>
+auto query::cond_purpose() const -> const std::bitset<num_purposes>&
 {
   return this->m_cond_purpose;
 }
 
-auto query::cond_objection() const -> std::bitset<num_purposes>
+auto query::cond_objection() const -> const std::bitset<num_purposes>&
 {
   return this->m_cond_objection;
 }
 
-auto query::cond_origin() const -> std::bitset<num_origins>
+auto query::cond_origin() const -> const std::bitset<num_origins>&
 {
   return this->m_cond_origin;
 }
@@ -291,7 +291,7 @@ auto query::cond_expiration() const -> int64_t
   return this->m_cond_expiration;
 }
 
-auto query::cond_share() const -> std::bitset<num_users>
+auto query::cond_share() const -> const std::bitset<num_users>&
 {
   return this->m_cond_share;
 }

--- a/controller/source/query.hpp
+++ b/controller/source/query.hpp
@@ -42,6 +42,7 @@ const std::vector<std::string> query_types = {
   "delete",
   "putm",
   "getm",
+  "putc",
   "getlogs"
 };
 // NOLINTEND(cert-err58-cpp)

--- a/controller/source/query.hpp
+++ b/controller/source/query.hpp
@@ -57,21 +57,21 @@ public:
   // ~query();
 
   /* private members getters */
-  [[nodiscard]] auto cmd() const -> std::string;
+  [[nodiscard]] auto cmd() const -> const std::string&;
   [[nodiscard]] auto key() const -> std::string_view;
   [[nodiscard]] auto value() const -> std::string_view;
-  [[nodiscard]] auto user_key() const -> std::optional<std::bitset<num_users>>;
-  [[nodiscard]] auto purpose() const -> std::optional<std::bitset<num_purposes>>;
-  [[nodiscard]] auto objection() const -> std::optional<std::bitset<num_purposes>>;
-  [[nodiscard]] auto origin() const -> std::optional<std::bitset<num_origins>>;
+  [[nodiscard]] auto user_key() const -> const std::optional<std::bitset<num_users>>&;
+  [[nodiscard]] auto purpose() const -> const std::optional<std::bitset<num_purposes>>&;
+  [[nodiscard]] auto objection() const -> const std::optional<std::bitset<num_purposes>>&;
+  [[nodiscard]] auto origin() const -> const std::optional<std::bitset<num_origins>>&;
   [[nodiscard]] auto expiration() const -> std::optional<int64_t>;
-  [[nodiscard]] auto share() const -> std::optional<std::bitset<num_users>>;
+  [[nodiscard]] auto share() const -> const std::optional<std::bitset<num_users>>&;
   [[nodiscard]] auto monitor() const -> std::optional<bool>;
-  [[nodiscard]] auto cond_purpose() const -> std::bitset<num_purposes>;
-  [[nodiscard]] auto cond_objection() const -> std::bitset<num_purposes>;
-  [[nodiscard]] auto cond_origin() const -> std::bitset<num_origins>;
+  [[nodiscard]] auto cond_purpose() const -> const std::bitset<num_purposes>&;
+  [[nodiscard]] auto cond_objection() const -> const std::bitset<num_purposes>&;
+  [[nodiscard]] auto cond_origin() const -> const std::bitset<num_origins>&;
   [[nodiscard]] auto cond_expiration() const -> int64_t;
-  [[nodiscard]] auto cond_share() const -> std::bitset<num_users>;
+  [[nodiscard]] auto cond_share() const -> const std::bitset<num_users>&;
   [[nodiscard]] auto cond_monitor() const -> bool;
   [[nodiscard]] auto log_key() const -> std::string_view;
 

--- a/controller/source/query.hpp
+++ b/controller/source/query.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <sstream>
 #include <unordered_map>
+#include <bitset>
 
 #include "gdpr_metadata.hpp"
 
@@ -59,18 +60,18 @@ public:
   [[nodiscard]] auto cmd() const -> std::string;
   [[nodiscard]] auto key() const -> std::string_view;
   [[nodiscard]] auto value() const -> std::string_view;
-  [[nodiscard]] auto user_key() const -> std::optional<std::string_view>;
+  [[nodiscard]] auto user_key() const -> std::optional<std::bitset<num_users>>;
   [[nodiscard]] auto purpose() const -> std::optional<std::bitset<num_purposes>>;
   [[nodiscard]] auto objection() const -> std::optional<std::bitset<num_purposes>>;
-  [[nodiscard]] auto origin() const -> std::optional<std::string_view>;
+  [[nodiscard]] auto origin() const -> std::optional<std::bitset<num_origins>>;
   [[nodiscard]] auto expiration() const -> std::optional<int64_t>;
-  [[nodiscard]] auto share() const -> std::optional<std::string_view>;
+  [[nodiscard]] auto share() const -> std::optional<std::bitset<num_users>>;
   [[nodiscard]] auto monitor() const -> std::optional<bool>;
   [[nodiscard]] auto cond_purpose() const -> std::bitset<num_purposes>;
   [[nodiscard]] auto cond_objection() const -> std::bitset<num_purposes>;
-  [[nodiscard]] auto cond_origin() const -> std::string_view;
+  [[nodiscard]] auto cond_origin() const -> std::bitset<num_origins>;
   [[nodiscard]] auto cond_expiration() const -> int64_t;
-  [[nodiscard]] auto cond_share() const -> std::string_view;
+  [[nodiscard]] auto cond_share() const -> std::bitset<num_users>;
   [[nodiscard]] auto cond_monitor() const -> bool;
   [[nodiscard]] auto log_key() const -> std::string_view;
 
@@ -88,20 +89,20 @@ private:
   std::string_view m_value;
 
   // metadata to set
-  std::optional<std::string_view> m_user_key;
+  std::optional<std::bitset<num_users>> m_user_key;
   std::optional<std::bitset<num_purposes>> m_purpose;
   std::optional<std::bitset<num_purposes>> m_objection;
-  std::optional<std::string> m_origin;
+  std::optional<std::bitset<num_origins>> m_origin;
   std::optional<int64_t> m_expiration;
-  std::optional<std::string_view> m_share;
+  std::optional<std::bitset<num_users>> m_share;
   std::optional<bool> m_monitor;
 
   // conditional metadata
   std::bitset<num_purposes> m_cond_purpose;
   std::bitset<num_purposes> m_cond_objection;
-  std::string_view m_cond_origin;
+  std::bitset<num_origins> m_cond_origin;
   int64_t m_cond_expiration;
-  std::string_view m_cond_share;
+  std::bitset<num_users> m_cond_share;
   bool m_cond_monitor;
 
   // log metadata

--- a/controller/source/query_rewriter.cpp
+++ b/controller/source/query_rewriter.cpp
@@ -44,11 +44,11 @@ query_rewriter::query_rewriter(const query &query_args,
 /* Constructor for put query operation rewriter in case of an UPDATE of a value */
 // To suppress bugprone-easily-swappable-parameters warning from clang-tidy
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-query_rewriter::query_rewriter(std::string_view res, std::string_view new_query_value)
+query_rewriter::query_rewriter(std::string_view value_or_metadata, std::string_view new_query_value)
 {
   // Decode the existing binary format
   size_t offset = 0;
-  metadata_header header = decode_header(res, offset);
+  metadata_header header = decode_header(value_or_metadata, offset);
 
   // Calculate where the old query value starts
   size_t metadata_size =  /* metadata header */   sizeof(metadata_header) + /* user key */    header.user_bytes     +
@@ -57,13 +57,16 @@ query_rewriter::query_rewriter(std::string_view res, std::string_view new_query_
   
   // Copy metadata prefix and append new query value
   m_new_value.reserve(metadata_size + new_query_value.size());
-  m_new_value.append(res.substr(0, metadata_size));
+  m_new_value.append(value_or_metadata.substr(0, metadata_size));
   m_new_value.append(new_query_value);
 }
 
-/* Constructor for PUTM query operation rewriter */
-query_rewriter::query_rewriter(std::string_view res,
-                               const query &query_args)
+/* Constructor for PUTM/PUTC query operation rewriter */
+/* create the new metadata fields based on the query arguments - the rest are left intact */
+/* in case of PUTC, also update the value based on the new_query_value provided parameter */
+query_rewriter::query_rewriter(const query &query_args,
+                               std::string_view res,
+                               std::optional<std::string_view> new_query_value = std::nullopt)
 {
   /* create the new metadata fields based on the query arguments - the rest are left intact */
   // Decode existing data
@@ -77,7 +80,8 @@ query_rewriter::query_rewriter(std::string_view res,
                       query_args.origin().has_value() ||
                       query_args.share().has_value() ||
                       query_args.expiration().has_value() ||
-                      query_args.monitor().has_value();
+                      query_args.monitor().has_value() ||
+                      new_query_value.has_value();
   
   if (!needs_update) {
     // No updates needed, just copy the original
@@ -95,10 +99,10 @@ query_rewriter::query_rewriter(std::string_view res,
 
   // Extract existing bitsets
   std::bitset<num_users> user_key;
-  std::bitset<num_purposes> purpose   = convert_to_bitset<num_purposes>(res, offset, header.purpose_bytes);
-  std::bitset<num_purposes> objection = convert_to_bitset<num_purposes>(res, offset, header.purpose_bytes);
-  std::bitset<num_origins> origin     = convert_to_bitset<num_origins>(res, offset, header.origin_bytes);
-  std::bitset<num_users> share        = convert_to_bitset<num_users>(res, offset, header.user_bytes);
+  std::bitset<num_purposes> purpose;
+  std::bitset<num_purposes> objection;
+  std::bitset<num_origins> origin;
+  std::bitset<num_users> share;
   
   size_t bitset_offset = offset;  // Save the current offset for bitsets
 
@@ -140,7 +144,12 @@ query_rewriter::query_rewriter(std::string_view res,
   }
 
   // Extract remaining query value
-  std::string_view query_value(res.data() + bitset_offset, res.size() - bitset_offset);
+  std::string_view query_value;
+  if (new_query_value.has_value()) {
+    query_value = new_query_value.value();
+  } else {
+    query_value = std::string_view(res.data() + bitset_offset, res.size() - bitset_offset);
+  }
 
   size_t total_size =  /* metadata header */  sizeof(metadata_header) + /* user key */    header.user_bytes     +
                       /* purpose */           header.purpose_bytes    + /* objection */   header.purpose_bytes  +
@@ -201,7 +210,7 @@ auto query_rewriter::decode_header(std::string_view new_value, size_t& offset) c
 }
 
 auto query_rewriter::new_value() && -> std::string {
-  return std::move(m_new_value);  // Transfer ownership via move
+  return std::move(m_new_value);  // Transfer ownership
 }
 
 } // namespace controller

--- a/controller/source/query_rewriter.cpp
+++ b/controller/source/query_rewriter.cpp
@@ -13,35 +13,35 @@ query_rewriter::query_rewriter(const query &query_args,
 {
   /* create the new value based on the query arguments and the default policy */
   /* note: string_view data type is okay as query outlives the query_rewriter */
-  std::string_view user_key = query_args.user_key().value_or(def_policy.user_key());
-  bool encryption = def_policy.encryption();
+  std::bitset<num_users> user_key = query_args.user_key().value_or(def_policy.user_key());
   std::bitset<num_purposes> purpose = query_args.purpose().value_or(def_policy.purpose());
   std::bitset<num_purposes> objection = query_args.objection().value_or(def_policy.objection());
-  std::string_view origin = query_args.origin().value_or(def_policy.origin());
+  std::bitset<num_origins> origin = query_args.origin().value_or(def_policy.origin());
+  std::bitset<num_users> share = query_args.share().value_or(def_policy.share());
+  bool encryption = def_policy.encryption();
   int64_t expiration = query_args.expiration().value_or(def_policy.expiration());
-  std::string_view share = query_args.share().value_or(def_policy.share());
   bool monitor = query_args.monitor().value_or(def_policy.monitor());
   
   // Pre-calculate the size of the final string
   size_t delimiters = (max_gdpr_field_guard - 1) * sizeof(char);
 
-  size_t prefix_size = /* user key */   user_key.size()            + /* encryption */  sizeof(char)               +
-                       /* purpose */    sizeof(unsigned long long) + /* objection */   sizeof(unsigned long long) +
-                       /* origin */     origin.size()              + /* expiration */  sizeof(int64_t)            +
-                       /* share */      share.size()               + /* monitor */     sizeof(char)               +
+  size_t prefix_size = /* user key */   num_users / 8 * sizeof(char)    + /* encryption */  sizeof(char)                    +
+                       /* purpose */    num_purposes / 8 * sizeof(char) + /* objection */   num_purposes / 8 * sizeof(char) +
+                       /* origin */     num_origins / 8 * sizeof(char)  + /* expiration */  sizeof(int64_t)                 +
+                       /* share */      num_users / 8 * sizeof(char)    + /* monitor */     sizeof(char)                    +
                        /* delimiters */ delimiters;
 
   // Reserve space for the entire string
   m_new_value.reserve(prefix_size + new_query_value.size());
 
   // Construct the string directly
-  m_new_value.append(user_key).append(1, '|');
+  m_new_value.append(bitmap_to_string(user_key)).append(1, '|');
   m_new_value.append(encryption ? "1|" : "0|");
-  m_new_value.append(std::to_string(purpose.to_ullong())).append(1, '|');
-  m_new_value.append(std::to_string(objection.to_ullong())).append(1, '|');
-  m_new_value.append(origin).append(1, '|');
+  m_new_value.append(bitmap_to_string(purpose)).append(1, '|');
+  m_new_value.append(bitmap_to_string(objection)).append(1, '|');
+  m_new_value.append(bitmap_to_string(origin)).append(1, '|');
   m_new_value.append(std::to_string(get_expiration_time(expiration))).append(1, '|');
-  m_new_value.append(share).append(1, '|');
+  m_new_value.append(bitmap_to_string(share)).append(1, '|');
   m_new_value.append(monitor ? "1|" : "0|");
   m_new_value.append(new_query_value);
 }
@@ -79,27 +79,35 @@ query_rewriter::query_rewriter(std::string_view res,
 
     switch (count) {
       case usr:
-        new_value.append(query_args.user_key().value_or(token));
+        if (query_args.user_key().has_value()) {
+          new_value.append(bitmap_to_string(query_args.user_key().value()));
+        } else {
+          new_value.append(token);
+        }
         break;
       case encr:
         new_value.append(token);
         break;
       case pur:
         if (query_args.purpose().has_value()) {
-          new_value.append(std::to_string(query_args.purpose().value().to_ullong()));
+          new_value.append(bitmap_to_string(query_args.purpose().value()));
         } else {
           new_value.append(token);
         }
         break;
       case obj:
         if (query_args.objection().has_value()) {
-          new_value.append(std::to_string(query_args.objection().value().to_ullong()));
+          new_value.append(bitmap_to_string(query_args.objection().value()));
         } else {
           new_value.append(token);
         }
         break;
       case org:
-        new_value.append(query_args.origin().value_or(token));
+        if (query_args.origin().has_value()) {
+          new_value.append(bitmap_to_string(query_args.origin().value()));
+        } else {
+          new_value.append(token);
+        }
         break;
       case exp:
         if (query_args.expiration().has_value()) {
@@ -109,7 +117,11 @@ query_rewriter::query_rewriter(std::string_view res,
         }
         break;
       case shr:
-        new_value.append(query_args.share().value_or(token));
+        if (query_args.share().has_value()) {
+          new_value.append(bitmap_to_string(query_args.share().value()));
+        } else {
+          new_value.append(token);
+        }
         break;
       case log:
         if (query_args.monitor().has_value()) {
@@ -144,10 +156,6 @@ query_rewriter::query_rewriter(std::string_view res,
 
   m_new_value = std::move(new_value);
 }
-
-// query_rewriter::~query_rewriter()
-// {
-// }
 
 auto query_rewriter::new_value() const -> std::string
 {

--- a/controller/source/query_rewriter.cpp
+++ b/controller/source/query_rewriter.cpp
@@ -1,4 +1,5 @@
 #include "query_rewriter.hpp"
+#include <iostream>
 
 namespace controller {
 
@@ -7,42 +8,36 @@ query_rewriter::query_rewriter()
 }
 
 /* Constructor for put query operation rewriter in case of the first INSERTION of a KV pair */
+/* create the new value based on the query arguments and the default policy */
 query_rewriter::query_rewriter(const query &query_args, 
                                const default_policy &def_policy,
                                std::string_view new_query_value)
 {
-  /* create the new value based on the query arguments and the default policy */
-  /* note: string_view data type is okay as query outlives the query_rewriter */
-  std::bitset<num_users> user_key = query_args.user_key().value_or(def_policy.user_key());
-  std::bitset<num_purposes> purpose = query_args.purpose().value_or(def_policy.purpose());
-  std::bitset<num_purposes> objection = query_args.objection().value_or(def_policy.objection());
-  std::bitset<num_origins> origin = query_args.origin().value_or(def_policy.origin());
-  std::bitset<num_users> share = query_args.share().value_or(def_policy.share());
-  bool encryption = def_policy.encryption();
-  int64_t expiration = query_args.expiration().value_or(def_policy.expiration());
-  bool monitor = query_args.monitor().value_or(def_policy.monitor());
-  
-  // Pre-calculate the size of the final string
-  size_t delimiters = (max_gdpr_field_guard - 1) * sizeof(char);
+  // Create header
+  metadata_header header;
+  header.flags = (def_policy.encryption() ? 1 : 0) | (query_args.monitor().value_or(def_policy.monitor()) ? 2 : 0);
+  header.expiration_time = query_args.expiration().value_or(def_policy.expiration());
 
-  size_t prefix_size = /* user key */   num_users / 8 * sizeof(char)    + /* encryption */  sizeof(char)                    +
-                       /* purpose */    num_purposes / 8 * sizeof(char) + /* objection */   num_purposes / 8 * sizeof(char) +
-                       /* origin */     num_origins / 8 * sizeof(char)  + /* expiration */  sizeof(int64_t)                 +
-                       /* share */      num_users / 8 * sizeof(char)    + /* monitor */     sizeof(char)                    +
-                       /* delimiters */ delimiters;
+  // Pre-calculate the size of the final string 
+  size_t total_size =  /* metadata header */    sizeof(metadata_header) + /* user key */    header.user_bytes     +
+                        /* purpose */           header.purpose_bytes    + /* objection */   header.purpose_bytes  +
+                        /* origin */            header.origin_bytes     + /* share */       header.user_bytes     + 
+                        /* new value */         new_query_value.size();
 
   // Reserve space for the entire string
-  m_new_value.reserve(prefix_size + new_query_value.size());
+  m_new_value.reserve(total_size);
 
-  // Construct the string directly
-  m_new_value.append(bitmap_to_string(user_key)).append(1, '|');
-  m_new_value.append(encryption ? "1|" : "0|");
-  m_new_value.append(bitmap_to_string(purpose)).append(1, '|');
-  m_new_value.append(bitmap_to_string(objection)).append(1, '|');
-  m_new_value.append(bitmap_to_string(origin)).append(1, '|');
-  m_new_value.append(std::to_string(get_expiration_time(expiration))).append(1, '|');
-  m_new_value.append(bitmap_to_string(share)).append(1, '|');
-  m_new_value.append(monitor ? "1|" : "0|");
+  // Append header
+  append_header(header);
+    
+  // Append bitsets as compact bytes
+  append_bitset(query_args.user_key().value_or(def_policy.user_key()));
+  append_bitset(query_args.purpose().value_or(def_policy.purpose()));
+  append_bitset(query_args.objection().value_or(def_policy.objection()));
+  append_bitset(query_args.origin().value_or(def_policy.origin()));
+  append_bitset(query_args.share().value_or(def_policy.share()));
+
+  // Append query value
   m_new_value.append(new_query_value);
 }
 
@@ -51,14 +46,19 @@ query_rewriter::query_rewriter(const query &query_args,
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 query_rewriter::query_rewriter(std::string_view res, std::string_view new_query_value)
 {
-  /* create the new value based on the current prefix and the new provided value */
-  // Find the position of the last "|" character in the string
-  size_t last_delimiter_pos = res.find_last_of('|');
+  // Decode the existing binary format
+  size_t offset = 0;
+  metadata_header header = decode_header(res, offset);
 
-  // Extract the substring up to the position of the last '|' character
-  auto metadata = res.substr(0, last_delimiter_pos);
-
-  m_new_value = std::string(metadata) + "|" + std::string(new_query_value);
+  // Calculate where the old query value starts
+  size_t metadata_size =  /* metadata header */   sizeof(metadata_header) + /* user key */    header.user_bytes     +
+                          /* purpose */           header.purpose_bytes    + /* objection */   header.purpose_bytes  +
+                          /* origin */            header.origin_bytes     + /* share */       header.user_bytes;
+  
+  // Copy metadata prefix and append new query value
+  m_new_value.reserve(metadata_size + new_query_value.size());
+  m_new_value.append(res.substr(0, metadata_size));
+  m_new_value.append(new_query_value);
 }
 
 /* Constructor for PUTM query operation rewriter */
@@ -66,100 +66,142 @@ query_rewriter::query_rewriter(std::string_view res,
                                const query &query_args)
 {
   /* create the new metadata fields based on the query arguments - the rest are left intact */
-  // Split the current value string into metadata fields + the value in the end
-  std::string new_value;
-  new_value.reserve(res.length());  // Pre-allocate space
-
-  size_t start = 0;
-  size_t end = 0;
-  int count = 0;
-
-  while (count < max_gdpr_field_guard && (end = res.find('|', start)) != std::string_view::npos) {
-    std::string_view token = res.substr(start, end - start);
-
-    switch (count) {
-      case usr:
-        if (query_args.user_key().has_value()) {
-          new_value.append(bitmap_to_string(query_args.user_key().value()));
-        } else {
-          new_value.append(token);
-        }
-        break;
-      case encr:
-        new_value.append(token);
-        break;
-      case pur:
-        if (query_args.purpose().has_value()) {
-          new_value.append(bitmap_to_string(query_args.purpose().value()));
-        } else {
-          new_value.append(token);
-        }
-        break;
-      case obj:
-        if (query_args.objection().has_value()) {
-          new_value.append(bitmap_to_string(query_args.objection().value()));
-        } else {
-          new_value.append(token);
-        }
-        break;
-      case org:
-        if (query_args.origin().has_value()) {
-          new_value.append(bitmap_to_string(query_args.origin().value()));
-        } else {
-          new_value.append(token);
-        }
-        break;
-      case exp:
-        if (query_args.expiration().has_value()) {
-          new_value.append(std::to_string(get_expiration_time(query_args.expiration().value())));
-        } else {
-          new_value.append(token);
-        }
-        break;
-      case shr:
-        if (query_args.share().has_value()) {
-          new_value.append(bitmap_to_string(query_args.share().value()));
-        } else {
-          new_value.append(token);
-        }
-        break;
-      case log:
-        if (query_args.monitor().has_value()) {
-          new_value.append(query_args.monitor().value() ? "1" : "0");
-        } else {
-          new_value.append(token);
-        }
-        break;
-      case val:
-        new_value.append(token);
-        break;
-      default:
-        break;
-    }
-    if (count != val) {
-      new_value.append(1, '|');
-    }
-    start = end + 1;
-    count++;
+  // Decode existing data
+  size_t offset = 0;
+  metadata_header header = decode_header(res, offset);
+  
+  // Check if we actually need to update anything
+  bool needs_update = query_args.user_key().has_value() || 
+                      query_args.purpose().has_value() ||
+                      query_args.objection().has_value() ||
+                      query_args.origin().has_value() ||
+                      query_args.share().has_value() ||
+                      query_args.expiration().has_value() ||
+                      query_args.monitor().has_value();
+  
+  if (!needs_update) {
+    // No updates needed, just copy the original
+    m_new_value = res;
+    return;
   }
 
-  // Append the last token (value)
-  if (start < res.length()) {
-    new_value.append(res.substr(start));
+  // Update header fields if needed
+  if (query_args.expiration().has_value()) {
+    header.expiration_time = get_expiration_time(query_args.expiration().value());
+  }
+  if (query_args.monitor().has_value()) {
+    header.flags = (header.flags & 1) | (query_args.monitor().value() ? 2 : 0);
   }
 
-#ifdef DEBUG
-  if (count != metadata_prefix_fields) {
-    throw std::invalid_argument("Invalid GDPR metadata format");
-  }
-#endif
+  // Extract existing bitsets
+  std::bitset<num_users> user_key;
+  std::bitset<num_purposes> purpose   = convert_to_bitset<num_purposes>(res, offset, header.purpose_bytes);
+  std::bitset<num_purposes> objection = convert_to_bitset<num_purposes>(res, offset, header.purpose_bytes);
+  std::bitset<num_origins> origin     = convert_to_bitset<num_origins>(res, offset, header.origin_bytes);
+  std::bitset<num_users> share        = convert_to_bitset<num_users>(res, offset, header.user_bytes);
+  
+  size_t bitset_offset = offset;  // Save the current offset for bitsets
 
-  m_new_value = std::move(new_value);
+  // Update with new values if provided
+  // User key
+  if (query_args.user_key().has_value()) {
+    user_key = query_args.user_key().value();
+    bitset_offset += header.user_bytes;  // Skip over existing data
+  } else {
+    user_key = convert_to_bitset<num_users>(res, bitset_offset, header.user_bytes);
+  }
+  // Purpose
+  if (query_args.purpose().has_value()) {
+    purpose = query_args.purpose().value();
+    bitset_offset += header.purpose_bytes;  // Skip over existing data
+  } else {
+    purpose = convert_to_bitset<num_purposes>(res, bitset_offset, header.purpose_bytes);
+  }
+  // Objection
+  if (query_args.objection().has_value()) {
+    objection = query_args.objection().value();
+    bitset_offset += header.purpose_bytes;  // Skip over existing data
+  } else {
+    objection = convert_to_bitset<num_purposes>(res, bitset_offset, header.purpose_bytes);
+  }
+  // Origin
+  if (query_args.origin().has_value()) {
+    origin = query_args.origin().value();
+    bitset_offset += header.origin_bytes;  // Skip over existing data
+  } else {
+    origin = convert_to_bitset<num_origins>(res, bitset_offset, header.origin_bytes);
+  }
+  // Share
+  if (query_args.share().has_value()) {
+    share = query_args.share().value();
+    bitset_offset += header.user_bytes;  // Skip over existing data
+  } else {
+    share = convert_to_bitset<num_users>(res, bitset_offset, header.user_bytes);
+  }
+
+  // Extract remaining query value
+  std::string_view query_value(res.data() + bitset_offset, res.size() - bitset_offset);
+
+  size_t total_size =  /* metadata header */  sizeof(metadata_header) + /* user key */    header.user_bytes     +
+                      /* purpose */           header.purpose_bytes    + /* objection */   header.purpose_bytes  +
+                      /* origin */            header.origin_bytes     + /* share */       header.user_bytes     + 
+                      /* new value */         query_value.size();
+
+  m_new_value.reserve(total_size);
+  
+  append_header(header);
+  append_bitset(user_key);
+  append_bitset(purpose);
+  append_bitset(objection);
+  append_bitset(origin);
+  append_bitset(share);
+  m_new_value.append(query_value);
 }
 
-auto query_rewriter::new_value() const -> std::string
-{
-  return this->m_new_value;
+template<size_t N>
+auto query_rewriter::append_bitset(const std::bitset<N>& bits) -> void {
+  constexpr size_t num_bytes = (N + 7) / 8;
+  
+  if constexpr (N <= 64) {
+    // For small bitsets, use direct conversion
+    uint64_t value = bits.to_ullong();
+    const char* value_ptr = reinterpret_cast<const char*>(&value);
+    m_new_value.append(value_ptr, num_bytes);
+  } else {
+    // For larger bitsets, use word-level operations
+    constexpr size_t words_needed = (num_bytes + 7) / 8;
+    
+    for (size_t word_idx = 0; word_idx < words_needed; ++word_idx) {
+      uint64_t word = 0;
+      size_t bit_offset = word_idx * 64;
+      
+      // Extract 64 bits at a time
+      for (size_t bit = 0; bit < 64 && bit_offset + bit < N; ++bit) {
+        if (bits[bit_offset + bit]) {
+          word |= (1ULL << bit);
+        }
+      }
+      
+      // Append the word as bytes
+      size_t bytes_in_word = std::min(size_t(8), num_bytes - word_idx * 8);
+      const char* word_ptr = reinterpret_cast<const char*>(&word);
+      m_new_value.append(word_ptr, bytes_in_word);
+    }
+  }
+}
+
+auto query_rewriter::append_header(const metadata_header& header) -> void {
+  m_new_value.append(reinterpret_cast<const char*>(&header), sizeof(header));
+}
+
+auto query_rewriter::decode_header(std::string_view new_value, size_t& offset) const -> metadata_header {
+  metadata_header header = *reinterpret_cast<const metadata_header*>(new_value.data() + offset);
+  offset += sizeof(metadata_header);
+  return header;
+}
+
+auto query_rewriter::new_value() && -> std::string {
+  return std::move(m_new_value);  // Transfer ownership via move
 }
 
 } // namespace controller

--- a/controller/source/query_rewriter.hpp
+++ b/controller/source/query_rewriter.hpp
@@ -31,6 +31,12 @@ public:
 
 private:
   std::string m_new_value;
+
+  // Helper function to convert bitmap to string for serialization
+  template<std::size_t N>
+  auto bitmap_to_string(const std::bitset<N>& bitmap) const -> std::string {
+    return std::to_string(bitmap.to_ullong());
+  }
 };
 
 } // namespace controller

--- a/controller/source/query_rewriter.hpp
+++ b/controller/source/query_rewriter.hpp
@@ -36,6 +36,7 @@ private:
   template<std::size_t N>
   auto bitmap_to_string(const std::bitset<N>& bitmap) const -> std::string {
     return std::to_string(bitmap.to_ullong());
+    //return bitmap.to_string(); // Convert to string and limit to byte size
   }
 };
 

--- a/controller/source/query_rewriter.hpp
+++ b/controller/source/query_rewriter.hpp
@@ -27,17 +27,16 @@ public:
                           const query &query_args);
   // ~query_rewriter();
 
-  [[nodiscard]] auto new_value() const -> std::string;
+  [[nodiscard]] auto new_value() && -> std::string;
 
 private:
   std::string m_new_value;
 
-  // Helper function to convert bitmap to string for serialization
-  template<std::size_t N>
-  auto bitmap_to_string(const std::bitset<N>& bitmap) const -> std::string {
-    return std::to_string(bitmap.to_ullong());
-    //return bitmap.to_string(); // Convert to string and limit to byte size
-  }
+  // Helper functions
+  template<size_t N>
+  auto append_bitset(const std::bitset<N>& bits) -> void;
+  auto append_header(const metadata_header& header) -> void;
+  auto decode_header(std::string_view new_value, size_t& offset) const -> metadata_header;
 };
 
 } // namespace controller

--- a/controller/source/query_rewriter.hpp
+++ b/controller/source/query_rewriter.hpp
@@ -22,9 +22,10 @@ public:
   /* Constructor for the PUT operation in case of an UPDATE of a value */
   explicit query_rewriter(std::string_view res,
                           std::string_view new_query_value);
-  /* Constructor for the PUTM operation */
-  explicit query_rewriter(std::string_view res,
-                          const query &query_args);
+  /* Constructor for the PUTM/PUTC operation */
+  explicit query_rewriter(const query &query_args,
+                          std::string_view res,
+                          std::optional<std::string_view> new_query_value);
   // ~query_rewriter();
 
   [[nodiscard]] auto new_value() && -> std::string;

--- a/controller/source/rocksdb_server/message.hpp
+++ b/controller/source/rocksdb_server/message.hpp
@@ -38,7 +38,7 @@ public:
   static auto deserialize(std::string_view raw_query) -> query_message
   {
     static const std::unordered_set<std::string_view> valid_query_types {
-      "get", "put", "del", "getm", "putm"
+      "get", "put", "del", "getm", "putm", "putc", "getlogs"
     };
 
     query_message request;

--- a/controller/source/rocksdb_server/rocksdb_proxy.hpp
+++ b/controller/source/rocksdb_server/rocksdb_proxy.hpp
@@ -34,7 +34,7 @@ public:
     if (query.get_command() == "get" || query.get_command() == "getm" ) {
       return get(query.get_key());
     }
-    if (query.get_command() == "put" || query.get_command() == "putm") {
+    if (query.get_command() == "put" || query.get_command() == "putm" || query.get_command() == "putc") {
       return put(query.get_key(), query.get_value());
     }
     return del(query.get_key());

--- a/policy_compiler/KV_interface.py
+++ b/policy_compiler/KV_interface.py
@@ -4,6 +4,7 @@ query_types = [
     "delete",
     "putm",
     "getm",
+    "putc",
     "getlogs"
 ]
 
@@ -41,6 +42,8 @@ def query_multiplexer(query, metadata):
         return putm(K, metadata) 
     elif query_cmd == "getm":
         return getm(K, metadata)
+    elif query_cmd == "putc":
+        return putc_filtered(K, V, metadata)
     elif query_cmd == "getlogs":
         return getLogs(K, metadata)
     else:
@@ -63,6 +66,12 @@ def put_filtered(K, V, metadata):
         return put(K, V)
     
     return (f"put {K} {V} {metadata}")
+
+def putc_filtered(K, V, metadata):
+    if metadata == "":
+        return put(K, V)
+    
+    return (f"putc {K} {V} {metadata}")
 
 def get_filtered(K, metadata):
     if metadata == "":


### PR DESCRIPTION
This PR mainly targers to adapt the `gdpr` metadata format to be more compact.
Aside of this, it performs optimizations to reduce data copying, improve `controller` readability, adjusts the eviction policy of the metadata cache.

More precisely, it includes:
- add debug print for binary metadata in `common.hpp`
- reduce data copies in `controller.cpp`
- adjust `gdpr_filter` to the new metadata binary format
- add metadata header structure and helper conversion functions in `gdpr_metadata.hpp`
- reduce data copies and adjust data types in `query` class
- adjust the `query_rewriter` class to the new binary format of the metadata
- reduce data copies in the caching layer
- adds `putc` operation that updates both data and metadata in a KV pair
- separates logic for `put` and `putc` to optimize query rewriting
- adjusts `query_rewriter` constructor for `putm` to accommodate `putc` as well and optimizes the `put` case
- adjusts `controller.cpp` to consider the `putc` case
- restructure of `filter_and_monitor` function for readability
- adaptation of the `put` logic for readability and usage of the optimized `query_rewriter` constructor
- modifies the cache eviction policy to be random and choose one of the first 20 items randomly